### PR TITLE
Make the call to `close_camera()` Idempotent

### DIFF
--- a/picamera2.py
+++ b/picamera2.py
@@ -68,10 +68,12 @@ class Picamera2:
         # Release this camera for use by others.
         if self.started:
             self.stop()
-        if self.verbose:
-            print("Close camera:", self.camera)
-        self.camera.release()
-        self.camera = None
+        
+        if self.camera is not None:
+            if self.verbose:
+                print("Closing camera:", self.camera)
+            self.camera.release()
+            self.camera = None
         self.camera_config = None
         self.libcamera_config = None
         self.streams = None


### PR DESCRIPTION
If the user calls `.close_camera()` when the object goes out of scope the `__del__` method will call it again. and result in this error logging:
```
Exception ignored in: <function Picamera2.__del__ at 0x734164a8>
Traceback (most recent call last):
  File "/home/pi/picamera2/picamera2.py", line 51, in __del__
    self.close_camera()
  File "/home/pi/picamera2/picamera2.py", line 73, in close_camera
    self.camera.release()
AttributeError: 'NoneType' object has no attribute 'release'
```

I would strongly recommend against using the python __del__ machinery more generally, but that is a conversation for another day.