### PR TITLE
Add an encoder class that allows multi-threaded software encode

### DIFF
--- a/examples/capture_mjpeg.py
+++ b/examples/capture_mjpeg.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+from null_preview import *
+from jpeg_encoder import *
+from picamera2 import *
+import time
+
+picam2 = Picamera2()
+video_config = picam2.video_configuration(main={"size": (1920, 1080)})
+picam2.configure(video_config)
+
+preview = NullPreview(picam2)
+encoder = JpegEncoder(q=70)
+
+encoder.output = open('test.mjpeg', 'wb')
+picam2.encoder = encoder
+picam2.start_encoder()
+picam2.start()
+time.sleep(10)
+picam2.stop()
+picam2.stop_encoder()

--- a/examples/capture_mjpeg.py
+++ b/examples/capture_mjpeg.py
@@ -12,10 +12,6 @@ picam2.configure(video_config)
 preview = NullPreview(picam2)
 encoder = JpegEncoder(q=70)
 
-encoder.output = open('test.mjpeg', 'wb')
-picam2.encoder = encoder
-picam2.start_encoder()
-picam2.start()
+picam2.start_recording(encoder, 'test.mjpeg')
 time.sleep(10)
-picam2.stop()
-picam2.stop_encoder()
+picam2.stop_recording()

--- a/examples/capture_video.py
+++ b/examples/capture_video.py
@@ -13,10 +13,6 @@ picam2.configure(video_config)
 preview = NullPreview(picam2)
 encoder = H264Encoder(10000000)
 
-encoder.output = open('test.h264', 'wb')
-picam2.encoder = encoder
-picam2.start_encoder()
-picam2.start()
+picam2.start_recording(encoder, 'test.h264')
 time.sleep(10)
-picam2.stop()
-picam2.stop_encoder()
+picam2.stop_recording()

--- a/examples/mjpeg_server.py
+++ b/examples/mjpeg_server.py
@@ -81,16 +81,12 @@ class StreamingServer(socketserver.ThreadingMixIn, server.HTTPServer):
 picam2 = picamera2.Picamera2()
 preview = null_preview.NullPreview(picam2)
 picam2.configure(picam2.video_configuration(main={"size": (640, 480)}))
-picam2.encoder = jpeg_encoder.JpegEncoder()
 output = StreamingOutput()
-picam2.encoder.output = output
-picam2.start_encoder()
-picam2.start()
+picam2.start_recording(jpeg_encoder.JpegEncoder(), output)
 
 try:
     address = ('', 8000)
     server = StreamingServer(address, StreamingHandler)
     server.serve_forever()
 finally:
-    picam2.stop()
-    picam2.stop_encoder()
+    picam2.stop_recording()

--- a/jpeg_encoder.py
+++ b/jpeg_encoder.py
@@ -1,0 +1,12 @@
+from multi_encoder import *
+import simplejpeg
+
+class JpegEncoder(MultiEncoder):
+    def __init__(self, num_threads=4, q=85, colour_space='RGBX'):
+        super().__init__(num_threads=num_threads)
+        self.q = q
+        self.colour_space = colour_space
+
+    def encode_func(self, request, name):
+        array = request.make_array(name)
+        return simplejpeg.encode_jpeg(array, quality=self.q, colorspace=self.colour_space)

--- a/multi_encoder.py
+++ b/multi_encoder.py
@@ -1,0 +1,47 @@
+from encoder import *
+import threading, queue
+from concurrent.futures import ThreadPoolExecutor
+
+class MultiEncoder(Encoder):
+    """This is a base class for a multi-threaded software encoder. Derive your encoder
+    from this class and add an encode_func method. For an example, see JpegEncoder
+    (jpeg_encoder.py). The parallelism is likely to help when the encoder in question
+    releases the GIL, for example before diving into a large C/C++ library.
+    Parameters:
+    num_threads - the number of parallel threads to use. Probably match this to the
+                  number of cores available for best performance.
+    """
+    def __init__(self, num_threads=4):
+        super().__init__()
+        self.threads = ThreadPoolExecutor(num_threads)
+        self.tasks = queue.Queue()
+
+    def _start(self):
+        super()._start()
+        self.thread = threading.Thread(target=self.output_thread, daemon=True)
+        self.thread.start()
+        
+    def _stop(self):
+        super()._stop()
+        self.tasks.put(None)
+        self.thread.join()
+
+    def output_thread(self):
+        while True:
+            task = self.tasks.get()
+            if task is None:
+                return
+
+            buffer = task.result()
+            if self._output is not None:
+                self._output.write(buffer)
+            
+    def do_encode(self, request):
+        buffer = self.encode_func(request, request.picam2.encode_stream_name)
+        request.release()
+        return buffer
+
+    def encode(self, stream, request):
+        if self._running:
+            request.acquire()
+            self.tasks.put(self.threads.submit(self.do_encode, request))

--- a/picamera2.py
+++ b/picamera2.py
@@ -747,6 +747,21 @@ class Picamera2:
             raise RuntimeError("Must pass encoder instance")
         self._encoder = value
 
+    def start_recording(self, encoder, output):
+        """Start recording a video using the given encoder and to the given output.
+        Output may be a string in which case the correspondingly named file is opened."""
+        if isinstance(output, str):
+            output = open(output, 'wb')
+        encoder.output = output
+        self.encoder = encoder
+        self.start_encoder()
+        self.start()
+
+    def stop_recording(self):
+        """Stop recording a video. The encode and output are stopped and closed."""
+        self.stop()
+        self.stop_encoder()
+        self.encoder.output.close()
 
 class CompletedRequest:
     def __init__(self, request, picam2):


### PR DESCRIPTION
We add:

MultiEncoder - a base class that can be derived from to implement
multi-threaded software encode.

JpegEncoder - an example using the MultiEncoder.

examples/capture_mjpeg.py - capture an MJPEG stream using the above.