### PR TITLE
Qtgl fix

### DIFF
--- a/picamera2/previews/drm_preview.py
+++ b/picamera2/previews/drm_preview.py
@@ -81,3 +81,11 @@ class DrmPreview(NullPreview):
         if self.current:
             self.current.release()
         self.current = completed_request
+
+    def stop(self):
+        super().stop()
+        # Seem to need some of this in order to be able to create another DrmPreview.
+        self.drmfbs = {}
+        self.crtc = None
+        self.resman = None
+        self.card = None

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -97,6 +97,11 @@ class QGlPicamera2(QWidget):
                                                self)
         self.camera_notifier.activated.connect(self.handle_requests)
 
+    def __del__(self):
+        del self.camera_notifier
+        eglDestroySurface(self.egl.display, self.surface)
+        self.surface = None
+
     def paintEngine(self):
         return None
 

--- a/picamera2/previews/qt_gl_preview.py
+++ b/picamera2/previews/qt_gl_preview.py
@@ -24,7 +24,6 @@ class QtGlPreview:
         atexit.unregister(self.stop)
         self.qpicamera2.picamera2.asynchronous = False
         # Again, all necessary to keep Qt quiet.
-        del self.qpicamera2.camera_notifier
         del self.qpicamera2
         del self.app
 

--- a/tests/drm_preview_test.py
+++ b/tests/drm_preview_test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+# Test that we can successfully close a QtGlPreview window and open a new one.
+
+from picamera2.picamera2 import *
+import time
+
+preview_type = Preview.DRM
+
+print("First preview...")
+picam2 = Picamera2()
+picam2.configure(picam2.preview_configuration())
+picam2.start_preview(preview_type)
+picam2.start()
+time.sleep(2)
+picam2.close()
+print("Done")
+
+print("Second preview...")
+picam2 = Picamera2()
+picam2.configure(picam2.preview_configuration())
+picam2.start_preview(preview_type)
+picam2.start()
+time.sleep(2)
+picam2.close()
+print("Done")

--- a/tests/qt_gl_preview_test.py
+++ b/tests/qt_gl_preview_test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+# Test that we can successfully close a QtGlPreview window and open a new one.
+
+from picamera2.picamera2 import *
+import time
+
+preview_type = Preview.QTGL
+
+print("First preview...")
+picam2 = Picamera2()
+picam2.configure(picam2.preview_configuration())
+picam2.start_preview(preview_type)
+picam2.start()
+time.sleep(2)
+picam2.close()
+print("Done")
+
+print("Second preview...")
+picam2 = Picamera2()
+picam2.configure(picam2.preview_configuration())
+picam2.start_preview(preview_type)
+picam2.start()
+time.sleep(2)
+picam2.close()
+print("Done")

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -18,3 +18,4 @@ examples/zoom.py
 tests/context_test.py
 tests/preview_cycle_test.py
 tests/preview_location_test.py
+tests/qt_gl_preview_test.py


### PR DESCRIPTION
These two commits improve the shutdown sequence of the QtGlPreview and DrmPreview windows, with the result that you can now successfully open a second one!