### PR TITLE
Overlays

### DIFF
--- a/examples/overlay_drm.py
+++ b/examples/overlay_drm.py
@@ -1,0 +1,17 @@
+from picamera2.picamera2 import *
+import numpy as np
+import time
+
+picam2 = Picamera2()
+picam2.configure(picam2.preview_configuration())
+picam2.start_preview(Preview.DRM)
+picam2.start()
+time.sleep(1)
+
+overlay = np.zeros((300, 400, 4), dtype=np.uint8)
+overlay[:150, 200:] = (255, 0, 0, 64)
+overlay[150:, :200] = (0, 255, 0, 64)
+overlay[150:, 200:] = (0, 0, 255, 64)
+
+picam2.set_overlay(overlay)
+time.sleep(2)

--- a/examples/overlay_gl.py
+++ b/examples/overlay_gl.py
@@ -1,0 +1,17 @@
+from picamera2.picamera2 import *
+import numpy as np
+import time
+
+picam2 = Picamera2()
+picam2.configure(picam2.preview_configuration())
+picam2.start_preview(Preview.QTGL)
+picam2.start()
+time.sleep(1)
+
+overlay = np.zeros((300, 400, 4), dtype=np.uint8)
+overlay[:150, 200:] = (255, 0, 0, 64)
+overlay[150:, :200] = (0, 255, 0, 64)
+overlay[150:, 200:] = (0, 0, 255, 64)
+
+picam2.set_overlay(overlay)
+time.sleep(2)

--- a/examples/overlay_null.py
+++ b/examples/overlay_null.py
@@ -1,0 +1,17 @@
+from picamera2.picamera2 import *
+import numpy as np
+import time
+
+picam2 = Picamera2()
+picam2.configure(picam2.preview_configuration())
+picam2.start_preview()
+picam2.start()
+time.sleep(1)
+
+overlay = np.zeros((300, 400, 4), dtype=np.uint8)
+overlay[:150, 200:] = (255, 0, 0, 64)
+overlay[150:, :200] = (0, 255, 0, 64)
+overlay[150:, 200:] = (0, 0, 255, 64)
+
+picam2.set_overlay(overlay)
+time.sleep(2)

--- a/examples/overlay_qt.py
+++ b/examples/overlay_qt.py
@@ -1,0 +1,17 @@
+from picamera2.picamera2 import *
+import numpy as np
+import time
+
+picam2 = Picamera2()
+picam2.configure(picam2.preview_configuration())
+picam2.start_preview(Preview.QT)
+picam2.start()
+time.sleep(1)
+
+overlay = np.zeros((300, 400, 4), dtype=np.uint8)
+overlay[:150, 200:] = (255, 0, 0, 64)
+overlay[150:, :200] = (0, 255, 0, 64)
+overlay[150:, 200:] = (0, 0, 255, 64)
+
+picam2.set_overlay(overlay)
+time.sleep(2)

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -862,6 +862,18 @@ class Picamera2:
         self.stop_encoder()
         self.encoder.output.close()
 
+    def set_overlay(self, overlay):
+        """Display an overlay on the camera image. The overlay may be either None,
+        in which case any overlay is removed, or a 4-channel image, the last of the
+        channels being taken as the alpha channel."""
+        if overlay is None:
+            pass  # OK
+        else:
+            shape = overlay.shape
+            if len(shape) != 3 or shape[2] != 4:
+                raise RuntimeError("Overlay must be a 4-channel image")
+        self._preview.set_overlay(overlay)
+
 
 class CompletedRequest:
     def __init__(self, request, picam2):

--- a/picamera2/previews/drm_preview.py
+++ b/picamera2/previews/drm_preview.py
@@ -1,7 +1,10 @@
 import picamera2.picamera2
 import pykms
+import mmap
+import numpy as np
 from picamera2.previews.null_preview import *
 
+dd = None
 
 class DrmPreview(NullPreview):
     FMT_MAP = {
@@ -36,6 +39,20 @@ class DrmPreview(NullPreview):
         self.drmfbs = {}
         self.current = None
         self.window = (x, y, width, height)
+        self.overlay_plane = None
+        self.overlay_fb = None
+        self.overlay_new_fb = None
+
+    def set_overlay(self, overlay):
+        if overlay is None:
+            self.overlay_new_fb = None
+        else:
+            h, w, channels = overlay.shape
+            # Should I be recycling these instead of making new ones all the time?
+            new_fb = pykms.DumbFramebuffer(self.card, w, h, "AB24")
+            with mmap.mmap(new_fb.fd(0), w * h * 4, mmap.MAP_SHARED, mmap.PROT_WRITE) as mm:
+                mm.write(np.ascontiguousarray(overlay).data)
+            self.overlay_new_fb = new_fb
 
     def render_drm(self, picam2, completed_request):
         if picam2.display_stream_name is None:
@@ -55,9 +72,14 @@ class DrmPreview(NullPreview):
             fmt = self.FMT_MAP[cfg.pixelFormat]
             if self.plane is None:
                 self.plane = self.resman.reserve_overlay_plane(self.crtc, fmt)
-                if picam2.verbose_console:
-                    print("Got plane", self.plane, "for format", fmt)
-                assert(self.plane)
+                if self.plane is None:
+                    raise RuntimeError("Failed to reserve DRM plane")
+                # The second plane we ask for will go on top of the first.
+                self.overlay_plane = self.resman.reserve_overlay_plane(self.crtc, pykms.PixelFormat.ABGR8888)
+                if self.overlay_plane is None:
+                    raise RuntimeError("Failed to reserve DRM overlay plane")
+                # Want "coverage" mode, not pre-multiplied alpha.
+                self.overlay_plane.set_prop("pixel blend mode", 1)
             fd = fb.fd(0)
             stride = cfg.stride
             if cfg.pixelFormat in ("YUV420", "YVU420"):
@@ -77,6 +99,21 @@ class DrmPreview(NullPreview):
         drmfb = self.drmfbs[fb]
         x, y, w, h = self.window
         self.crtc.set_plane(self.plane, drmfb, x, y, w, h, 0, 0, width, height)
+        # An "atomic commit" would probably be better, but I can't get this to work...
+        # ctx = pykms.AtomicReq(self.card)
+        # ctx.add(self.plane, {"FB_ID": drmfb.id, "CRTC_ID": self.crtc.id,
+        #                      "SRC_W": width << 16, "SRC_H": height << 16,
+        #                      "CRTC_X": x, "CRTC_Y": y, "CRTC_W": w, "CRTC_H": h})
+        # ctx.commit()
+
+        overlay_new_fb = self.overlay_new_fb
+        if overlay_new_fb != self.overlay_fb:
+            overlay_old_fb = self.overlay_fb  # Must hang on to this momentarily to avoid a "wink"
+            self.overlay_fb = overlay_new_fb
+        if self.overlay_fb is not None:
+            width, height = self.overlay_fb.width, self.overlay_fb.height
+            self.crtc.set_plane(self.overlay_plane, self.overlay_fb, x, y, w, h, 0, 0, width, height)
+        overlay_old_fb = None  # The new one has been sent so it's safe to let this go now
 
         if self.current:
             self.current.release()
@@ -86,6 +123,8 @@ class DrmPreview(NullPreview):
         super().stop()
         # Seem to need some of this in order to be able to create another DrmPreview.
         self.drmfbs = {}
+        self.overlay_new_fb = None
+        self.overlay_fb = None
         self.crtc = None
         self.resman = None
         self.card = None

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -32,6 +32,10 @@ class NullPreview:
         self.thread.start()
         self.event.wait()
 
+    def set_overlay(self, overlay):
+        # This only exists so as to have the same interface as other preview windows.
+        pass
+
     def handle_request(self, picam2):
         completed_request = picam2.process_requests()
         if completed_request:

--- a/picamera2/previews/qt_gl_preview.py
+++ b/picamera2/previews/qt_gl_preview.py
@@ -43,3 +43,6 @@ class QtGlPreview:
         if hasattr(self, "app"):
             self.app.quit()
         self.thread.join()
+
+    def set_overlay(self, overlay):
+        self.qpicamera2.set_overlay(overlay)

--- a/picamera2/previews/qt_preview.py
+++ b/picamera2/previews/qt_preview.py
@@ -45,3 +45,6 @@ class QtPreview:
         if hasattr(self, "app"):
             self.app.quit()
         self.thread.join()
+
+    def set_overlay(self, overlay):
+        self.qpicamera2.set_overlay(overlay)

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -9,6 +9,9 @@ examples/exposure_fixed.py
 examples/metadata.py
 examples/opencv_face_detect_2.py
 examples/opencv_mertens_merge.py
+examples/overlay_gl.py
+examples/overlay_null.py
+examples/overlay_qt.py
 examples/preview.py
 examples/preview_x_forwarding.py
 examples/raw.py


### PR DESCRIPTION
The commits here implement overlays, that is, the ability to draw alpha-blended overlays on top of the camera image in the various types of preview window, without changing the actual camera image underneath. This entire feature is made up of 6 commits:

1. The first commit implements overlays in the OpenGL preview window. There's also a very small amount of plumbing just to send the overlay from the Picamera object to the preview.
2. The second commit repeats this work for the simple Qt software-rendered version of the preview window.
3. Next we do it all again for the DRM/KMS version of the preview.
4. Finally we do the same for the `NullPreview`. Of course this doesn't do anything, we just want it to have the same API.
5. This commit adds some simple overlay examples and also puts them into the standard test list.
6. The final commit updates the docuementation in the README.md file.