### PR TITLE
Include EXIF data when saving JPEG files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Finally fetch the *Picamera2* repository. There are a couple of dependencies to 
 
 ```
 cd
-sudo pip3 install pyopengl
+sudo pip3 install pyopengl piexif
 sudo apt install -y python3-pyqt5
 git clone https://github.com/raspberrypi/picamera2.git
 ```


### PR DESCRIPTION
We add exposure time, ISO (gain), make and model.

Note that you will now need piexif (pip install piexif) in order to be
able to load picamera2.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>