### PR TITLE
Add tuning parameter to Picamera2 constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,14 @@ picam2.configure(preview_configuration)
 picam2.start()
 ```
 
+## The Tuning File
+
+Being Python-based, _Picamera2_ is a good environment for inspecting and altering the _tuning files_ that Raspberry Pi ships for all its supported cameras.
+
+A _tuning file_ lists all the parameters needed for a specific camera to produce images of acceptable quality, configuring both hardware (specifically of the ISP, or _Image Signal Processor_) and also of the 3A and other real-time algorithms that run to control the behaviour of the camera system.
+
+This is a more advanced topic, so readers are referred to the [Raspberry Pi Camera Algorithm and Tuning Guide](https://datasheets.raspberrypi.com/camera/raspberry-pi-camera-guide.pdf), and to chapter 5 in particular, for a more detailed explanation. We also provide an example [`tuning_file.py`](#tuning_filepy) which illustrates one simple way to use this feature.
+
 ## Examples
 
 A number of small example programs are provided in the [`examples`](examples) folder. Users who are new to *Picamera2* should probably start with the following:
@@ -406,6 +414,12 @@ Example of how to switch between one camera mode and another. In this case we re
 ### [switch_mode_2.py](examples/switch_mode_2.py)
 
 Alternative example of how to switch camera modes (like [switch_mode.py](#switch_modepy)). Under the hood both methods are in fact doing exactly the same thing.
+
+### [tuning_file.py](examples/tuning_file.py)
+
+The camera _tuning file_ is actually a JSON file, so it can be readily loaded into a Python application. We provide a function `load_tuning_file` to do exactly this, and then the tuning file object, a Python dictionary, is easily manipulated.
+
+When the `Picamera2` instance is created, it can optionally be passed either the file name of a custom camera tuning file, or a Python tuning file object. In this example we substitute the default exposure profile for one that prefers longer exposure times, and only ramps the analogue gain as a last resort. For more information on the algorithms and parameters permitted in the tuning file, please consult the [Raspberry Pi Camera Algorithm and Tuning Guide](https://datasheets.raspberrypi.com/camera/raspberry-pi-camera-guide.pdf).
 
 ### [yuv_to_rgb.py](examples/yuv_to_rgb.py)
 

--- a/examples/tuning_file.py
+++ b/examples/tuning_file.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+
+from picamera2.picamera2 import *
+
+# Here we load up the tuning for the HQ cam and alter the default exposure profile.
+# For more information on what can be changed, see chapter 5 in
+# https://datasheets.raspberrypi.com/camera/raspberry-pi-camera-guide.pdf
+
+tuning = Picamera2.load_tuning_file("imx477.json")
+tuning["rpi.agc"]["exposure_modes"]["normal"] = {"shutter": [100, 66666], "gain": [1.0, 8.0]}
+
+picam2 = Picamera2(tuning=tuning)
+picam2.configure(picam2.preview_configuration())
+picam2.start_preview(Preview.QTGL)
+picam2.start()
+time.sleep(2)

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -16,6 +16,7 @@ examples/rotation.py
 examples/still_during_video.py
 examples/switch_mode.py
 examples/switch_mode_2.py
+examples/tuning_file.py
 examples/zoom.py
 tests/context_test.py
 tests/preview_cycle_test.py


### PR DESCRIPTION
This allows a custom camera tuning file to be named, or for a tuning
object (a custom Python dictionary) to be passed in.

An example (examples/tuning_file.py) has been added, and included in
the standard test list, and documentation added.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>