### PR TITLE
Changes to rgb stream alignment and addition of rgb2* functions.

### DIFF
--- a/examples/app_capture.py
+++ b/examples/app_capture.py
@@ -3,15 +3,15 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtWidgets import *
 
-from picamera2.previews.q_gl_picamera2 import *
-from picamera2.picamera2 import *
+from PiCamera2.previews.q_gl_PiCamera2 import *
+from PiCamera2.PiCamera2 import *
 
 
 def request_callback(request):
     label.setText(''.join("{}: {}\n".format(k, v) for k, v in request.get_metadata().items()))
 
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.request_callback = request_callback
 picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
 
@@ -26,12 +26,12 @@ def on_button_clicked():
         print("Busy!")
 
 
-qpicamera2 = QGlPicamera2(picam2, width=800, height=600)
+qPiCamera2 = QGlPiCamera2(picam2, width=800, height=600)
 button = QPushButton("Click to capture JPEG")
 button.clicked.connect(on_button_clicked)
 label = QLabel()
 window = QWidget()
-window.setWindowTitle("Qt Picamera2 App")
+window.setWindowTitle("Qt PiCamera2 App")
 
 label.setFixedWidth(400)
 label.setAlignment(QtCore.Qt.AlignTop)
@@ -39,7 +39,7 @@ layout_h = QHBoxLayout()
 layout_v = QVBoxLayout()
 layout_v.addWidget(label)
 layout_v.addWidget(button)
-layout_h.addWidget(qpicamera2, 80)
+layout_h.addWidget(qPiCamera2, 80)
 layout_h.addLayout(layout_v, 20)
 window.resize(1200, 600)
 window.setLayout(layout_h)

--- a/examples/capture_array_and_convert.py
+++ b/examples/capture_array_and_convert.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+from datetime import datetime,timezone
+import os
+from picamera2.picamera2 import *
+from picamera2.converters import *
+
+
+user = os.getlogin() #Get the current user.
+save_dir = f'/home/{user}/Pictures' #Let's save images to this directory.
+
+picam2 = Picamera2()
+config = picam2.still_configuration()
+picam2.configure(config)
+picam2.start_preview()
+
+picam2.start()
+
+filename = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+rgb = picam2.capture_array()
+
+picam2.stop_preview()
+picam2.stop()
+picam2.close()
+
+
+#Convert captured rgb values to different filetypes.
+npy = rgb2npy(rgb,filename,save_dir)
+print(f'Saved .npy file to {npy}.')
+
+jpg = rgb2jpg(rgb,filename,save_dir)
+print(f'Saved .jpg file to {jpg}.')
+
+tif = rgb2tif(rgb,filename,save_dir)
+print(f'Saved .tif file to {tif}.')
+
+print('Saving rgb array as png...')
+png = rgb2png(rgb,filename,save_dir)
+print(f'Saved .png file to {png}.')
+
+
+

--- a/examples/capture_array_and_convert.py
+++ b/examples/capture_array_and_convert.py
@@ -2,14 +2,14 @@
 
 from datetime import datetime,timezone
 import os
-from picamera2.picamera2 import *
-from picamera2.converters import *
+from PiCamera2.PiCamera2 import *
+from PiCamera2.converters import *
 
 
 user = os.getlogin() #Get the current user.
 save_dir = f'/home/{user}/Pictures' #Let's save images to this directory.
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 config = picam2.still_configuration()
 picam2.configure(config)
 picam2.start_preview()

--- a/examples/capture_full_res.py
+++ b/examples/capture_full_res.py
@@ -2,10 +2,10 @@
 
 # Capture a JPEG while still running in the preview mode.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/capture_headless.py
+++ b/examples/capture_headless.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 config = picam2.still_configuration()
 picam2.configure(config)
 

--- a/examples/capture_headless.py
+++ b/examples/capture_headless.py
@@ -1,4 +1,4 @@
-#!//usr/bin/python3
+#!/usr/bin/python3
 
 from picamera2.picamera2 import *
 

--- a/examples/capture_image_full_res.py
+++ b/examples/capture_image_full_res.py
@@ -2,10 +2,10 @@
 
 # Capture a full resolution image to memory rather than to a file.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 preview_config = picam2.preview_configuration()
 capture_config = picam2.still_configuration()

--- a/examples/capture_jpeg.py
+++ b/examples/capture_jpeg.py
@@ -3,10 +3,10 @@
 # Capture a JPEG while still running in the preview mode. When you
 # capture to a file, the return value is the metadata for that image.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 
 preview_config = picam2.preview_configuration(main={"size": (800, 600)})
 picam2.configure(preview_config)

--- a/examples/capture_mjpeg.py
+++ b/examples/capture_mjpeg.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
 
-from picamera2.encoders.jpeg_encoder import *
-from picamera2.picamera2 import *
+from PiCamera2.encoders.jpeg_encoder import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 video_config = picam2.video_configuration(main={"size": (1920, 1080)})
 picam2.configure(video_config)
 

--- a/examples/capture_motion.py
+++ b/examples/capture_motion.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python3
 
-from picamera2.encoders.h264_encoder import *
-from picamera2.picamera2 import *
+from PiCamera2.encoders.h264_encoder import *
+from PiCamera2.PiCamera2 import *
 from signal import pause
 import numpy as np
 import time
 
 lsize = (320, 240)
-picam2 = Picamera2()
+picam2 = PiCamera2()
 video_config = picam2.video_configuration(main={"size": (1280, 720), "format": "RGB888"}, 
                                           lores={"size": lsize, "format": "YUV420"})
 picam2.configure(video_config)

--- a/examples/capture_png.py
+++ b/examples/capture_png.py
@@ -2,10 +2,10 @@
 
 # Capture a PNG while still running in the preview mode.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration(main={"size": (800, 600)})

--- a/examples/capture_stream.py
+++ b/examples/capture_stream.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
-from picamera2.encoders.h264_encoder import *
-from picamera2.picamera2 import *
+from PiCamera2.encoders.h264_encoder import *
+from PiCamera2.PiCamera2 import *
 import socket
 import time
 import os
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 video_config = picam2.video_configuration({"size": (1280, 720)})
 picam2.configure(video_config)
 picam2.start_preview()

--- a/examples/capture_video.py
+++ b/examples/capture_video.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
 
-from picamera2.encoders.h264_encoder import *
-from picamera2.picamera2 import *
+from PiCamera2.encoders.h264_encoder import *
+from PiCamera2.PiCamera2 import *
 import time
 import os
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 video_config = picam2.video_configuration()
 picam2.configure(video_config)
 

--- a/examples/controls.py
+++ b/examples/controls.py
@@ -3,10 +3,10 @@
 # Example of setting controls. Here, after one second, we fix the AGC/AEC
 # to the values it has reached whereafter it will no longer change.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/controls_2.py
+++ b/examples/controls_2.py
@@ -2,10 +2,10 @@
 
 # Another (simpler!) way to fix the AEC/AGC and AWB.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/exposure_fixed.py
+++ b/examples/exposure_fixed.py
@@ -2,10 +2,10 @@
 
 # Start camera with fixed exposure and gain.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/metadata.py
+++ b/examples/metadata.py
@@ -2,10 +2,10 @@
 
 # Obtain the current camera control values in the image metadata.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/metadata_with_image.py
+++ b/examples/metadata_with_image.py
@@ -3,10 +3,10 @@
 # Obtain an image from the camera along with the exact metadata that
 # that describes that image.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/mjpeg_server.py
+++ b/examples/mjpeg_server.py
@@ -4,8 +4,8 @@
 # Run this script, then point a web browser at http:<this-ip-address>:8000
 # Note: needs simplejpeg to be installed (pip3 install simplejpeg).
 
-from picamera2.picamera2 import *
-from picamera2.encoders.jpeg_encoder import *
+from PiCamera2.PiCamera2 import *
+from PiCamera2.encoders.jpeg_encoder import *
 import io
 import logging
 import socketserver
@@ -15,10 +15,10 @@ from http import server
 PAGE = """\
 <html>
 <head>
-<title>picamera2 MJPEG streaming demo</title>
+<title>PiCamera2 MJPEG streaming demo</title>
 </head>
 <body>
-<h1>Picamera2 MJPEG Streaming Demo</h1>
+<h1>PiCamera2 MJPEG Streaming Demo</h1>
 <img src="stream.mjpg" width="640" height="480" />
 </body>
 </html>
@@ -81,7 +81,7 @@ class StreamingServer(socketserver.ThreadingMixIn, server.HTTPServer):
     daemon_threads = True
 
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview()
 picam2.configure(picam2.video_configuration(main={"size": (640, 480)}))
 output = StreamingOutput()

--- a/examples/opencv_face_detect.py
+++ b/examples/opencv_face_detect.py
@@ -2,14 +2,14 @@
 
 import cv2
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 
 # Grab images as numpy arrays and leave everything else to OpenCV.
 
 face_detector = cv2.CascadeClassifier("/usr/share/opencv4/haarcascades/haarcascade_frontalface_default.xml")
 cv2.startWindowThread()
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview()
 picam2.configure(picam2.preview_configuration(main={"format": 'XRGB8888', "size": (640, 480)}))
 picam2.start()

--- a/examples/opencv_face_detect_2.py
+++ b/examples/opencv_face_detect_2.py
@@ -2,7 +2,7 @@
 
 import cv2
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 
 # This version creates a lores YUV stream, extracts the Y channel and runs the face
 # detector directly on that. We use the supplied OpenGL accelerated preview window
@@ -23,7 +23,7 @@ def draw_faces(request):
         del im
 
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 config = picam2.preview_configuration(main={"size": (640, 480)},
                                       lores={"size": (320, 240), "format": "YUV420"})

--- a/examples/opencv_mertens_merge.py
+++ b/examples/opencv_mertens_merge.py
@@ -3,12 +3,12 @@
 import cv2
 import time
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 
 # Simple Mertens merge with 3 exposures. No image alignment or anything fancy.
 RATIO = 3.0
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview()
 picam2.configure(picam2.preview_configuration())
 picam2.start()

--- a/examples/overlay_drm.py
+++ b/examples/overlay_drm.py
@@ -1,8 +1,8 @@
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import numpy as np
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.configure(picam2.preview_configuration())
 picam2.start_preview(Preview.DRM)
 picam2.start()

--- a/examples/overlay_gl.py
+++ b/examples/overlay_gl.py
@@ -1,8 +1,8 @@
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import numpy as np
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.configure(picam2.preview_configuration())
 picam2.start_preview(Preview.QTGL)
 picam2.start()

--- a/examples/overlay_null.py
+++ b/examples/overlay_null.py
@@ -1,8 +1,8 @@
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import numpy as np
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.configure(picam2.preview_configuration())
 picam2.start_preview()
 picam2.start()

--- a/examples/overlay_qt.py
+++ b/examples/overlay_qt.py
@@ -1,8 +1,8 @@
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import numpy as np
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.configure(picam2.preview_configuration())
 picam2.start_preview(Preview.QT)
 picam2.start()

--- a/examples/preview.py
+++ b/examples/preview.py
@@ -3,10 +3,10 @@
 # Normally the QtGlPreview implementation is recommended as it benefits
 # from GPU hardware acceleration.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/preview_drm.py
+++ b/examples/preview_drm.py
@@ -2,10 +2,10 @@
 
 # For use from the login console, when not running X Windows.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.DRM, x=100, y=100, width=640, height=480)
 
 preview_config = picam2.preview_configuration()

--- a/examples/preview_null.py
+++ b/examples/preview_null.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 
 import time
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 config = picam2.preview_configuration()
 picam2.configure(config)
 

--- a/examples/preview_x_forwarding.py
+++ b/examples/preview_x_forwarding.py
@@ -3,10 +3,10 @@
 # The QtPreview uses software rendering and thus makes more use of the
 # CPU, but it does work with X forwarding, unlike the QtGlPreview.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QT)
 
 preview_config = picam2.preview_configuration()

--- a/examples/raw.py
+++ b/examples/raw.py
@@ -2,10 +2,10 @@
 
 # Configure a raw stream and capture an image from it.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration(raw={"size": picam2.sensor_resolution})

--- a/examples/rotation.py
+++ b/examples/rotation.py
@@ -2,10 +2,10 @@
 
 # Run the camera with a 180 degree rotation.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/still_during_video.py
+++ b/examples/still_during_video.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python3
 
-from picamera2.encoders.h264_encoder import *
-from picamera2.picamera2 import *
+from PiCamera2.encoders.h264_encoder import *
+from PiCamera2.PiCamera2 import *
 import time
 import os
 
 # Encode a VGA stream, and capture a higher resolution still image half way through.
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 half_resolution = [dim // 2 for dim in picam2.sensor_resolution]
 main_stream = {"size": half_resolution}
 lores_stream = {"size": (640, 480)}

--- a/examples/switch_mode.py
+++ b/examples/switch_mode.py
@@ -2,10 +2,10 @@
 
 # Switch from preview to full resolution mode.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/switch_mode_2.py
+++ b/examples/switch_mode_2.py
@@ -2,10 +2,10 @@
 
 # Switch from preview to full resolution mode (alternative method).
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/examples/tensorflow/README.md
+++ b/examples/tensorflow/README.md
@@ -2,9 +2,9 @@
 
 TensorFlow Lite inferencing examples that carry out real-time object detection and labelling in a QT preview window using the [MobileNet V2](https://arxiv.org/abs/1801.04381) network trained on the [COCO dataset](https://cocodataset.org/#home).
 
-## Installing Picamera2
+## Installing PiCamera2
 
-Ensure that you have installed the Picamera2 library along with OpenCV. 
+Ensure that you have installed the PiCamera2 library along with OpenCV. 
 
 ```
 $ sudo apt update
@@ -15,7 +15,7 @@ $ sudo apt install -y meson
 $ sudo pip3 install pyyaml ply
 $ sudo pip3 install --upgrade meson
 $ sudo apt install -y libglib2.0-dev libgstreamer-plugins-base1.0-dev
-$ git clone --branch picamera2 git@github.com:raspberrypi/libcamera.git
+$ git clone --branch PiCamera2 git@github.com:raspberrypi/libcamera.git
 $ cd libcamera
 $ meson build --buildtype=release -Dpipelines=raspberrypi -Dipas=raspberrypi -Dv4l2=true -Dgstreamer=enabled -Dtest=false -Dlc-compliance=disabled -Dcam=disabled -Dqcam=enabled -Ddocumentation=disabled -Dpycamera=enabled
 $ ninja -C build 
@@ -30,11 +30,11 @@ $ ninja -C build
 $ cd
 $ sudo pip3 install pyopengl
 $ sudo apt install python3-pyqt5
-$ git clone git@github.com:raspberrypi/picamera2.git
+$ git clone git@github.com:raspberrypi/PiCamera2.git
 $ sudo pip3 install opencv-python==4.4.0.46
 $ sudo apt install -y libatlas-base-dev
 $ sudo pip3 install numpy --upgrade
-$ export PYTHONPATH=/home/pi/picamera2:/home/pi/libcamera/build/src/py:/home/pi/kmsxx/build/py
+$ export PYTHONPATH=/home/pi/PiCamera2:/home/pi/libcamera/build/src/py:/home/pi/kmsxx/build/py
 ```
 
 **NOTE:** Instructions are for the 32-bit version of Raspberry Pi OS.

--- a/examples/tensorflow/real_time.py
+++ b/examples/tensorflow/real_time.py
@@ -4,7 +4,7 @@
 # Author: Alasdair Allan <alasdair@raspberrypi.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-# A TensorFlow Lite example for Picamera2 on Raspberry Pi OS Bullseye
+# A TensorFlow Lite example for PiCamera2 on Raspberry Pi OS Bullseye
 #
 # Install necessary dependences before starting,
 #
@@ -32,7 +32,7 @@ import numpy as np
 from PIL import Image
 from PIL import ImageFont, ImageDraw
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 
 normalSize = (640, 480)
 lowresSize = (320, 240)
@@ -135,7 +135,7 @@ def main():
     else:
         label_file = None
 
-    picam2 = Picamera2()
+    picam2 = PiCamera2()
     picam2.start_preview(Preview.QTGL)
     config = picam2.preview_configuration(main={"size": normalSize},
                                           lores={"size": lowresSize, "format": "YUV420"})

--- a/examples/tensorflow/real_time_with_labels.py
+++ b/examples/tensorflow/real_time_with_labels.py
@@ -4,7 +4,7 @@
 # Author: Alasdair Allan <alasdair@raspberrypi.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
-# A TensorFlow Lite example for Picamera2 on Raspberry Pi OS Bullseye
+# A TensorFlow Lite example for PiCamera2 on Raspberry Pi OS Bullseye
 #
 # Install necessary dependences before starting,
 #
@@ -32,7 +32,7 @@ import numpy as np
 from PIL import Image
 from PIL import ImageFont, ImageDraw
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 
 normalSize = (640, 480)
 lowresSize = (320, 240)
@@ -141,7 +141,7 @@ def main():
     else:
         label_file = None
 
-    picam2 = Picamera2()
+    picam2 = PiCamera2()
     picam2.start_preview(Preview.QTGL)
     config = picam2.preview_configuration(main={"size": normalSize},
                                           lores={"size": lowresSize, "format": "YUV420"})

--- a/examples/tuning_file.py
+++ b/examples/tuning_file.py
@@ -1,15 +1,15 @@
 #!/usr/bin/python3
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 
 # Here we load up the tuning for the HQ cam and alter the default exposure profile.
 # For more information on what can be changed, see chapter 5 in
 # https://datasheets.raspberrypi.com/camera/raspberry-pi-camera-guide.pdf
 
-tuning = Picamera2.load_tuning_file("imx477.json")
+tuning = PiCamera2.load_tuning_file("imx477.json")
 tuning["rpi.agc"]["exposure_modes"]["normal"] = {"shutter": [100, 66666], "gain": [1.0, 8.0]}
 
-picam2 = Picamera2(tuning=tuning)
+picam2 = PiCamera2(tuning=tuning)
 picam2.configure(picam2.preview_configuration())
 picam2.start_preview(Preview.QTGL)
 picam2.start()

--- a/examples/yuv_to_rgb.py
+++ b/examples/yuv_to_rgb.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
-from picamera2.picamera2 import *
-from picamera2.converters import *
+from PiCamera2.PiCamera2 import *
+from PiCamera2.converters import *
 import cv2
 
 cv2.startWindowThread()
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview()
 config = picam2.preview_configuration(lores={"size": (640, 480)})
 picam2.configure(config)

--- a/examples/zoom.py
+++ b/examples/zoom.py
@@ -2,10 +2,10 @@
 
 # How to do digital zoom using the "ScalerCrop" control.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()

--- a/picamera2/converters.py
+++ b/picamera2/converters.py
@@ -1,10 +1,52 @@
 import numpy as np
+import os
+from PIL import Image
+
+YUV2RGB_JPEG      = np.array([[1.0,   1.0,   1.0  ], [0.0, -0.344, 1.772], 
+                              [1.402, -0.714, 0.0]])
+YUV2RGB_SMPTE170M = np.array([[1.164, 1.164, 1.164], [0.0, -0.392, 2.017], 
+                              [1.596, -0.813, 0.0]])
+YUV2RGB_REC709    = np.array([[1.164, 1.164, 1.164], [0.0, -0.213, 2.112], 
+                              [1.793, -0.533, 0.0]])
+
+def _rgb_to_fmt(image_array,filename,save_dir,fmt):
+    filepath,filename = os.path.split(filename)
+    basename,ext = os.path.splitext(filename)
+    if fmt not in basename:
+        filename = basename + fmt
+    if save_dir is not None:
+        abs_path = os.path.normpath(os.path.join(save_dir,filename))
+    else:
+        abs_path = filename #If the filename is not a path, then it will save in the current working directory.
+    if '.npy' in filename:
+        np.save(abs_path,image_array)
+    else:
+        img = Image.fromarray(image_array)
+        if '.jpg' in filename:
+            img = img.convert('RGB')
+        img.save(abs_path)
+    return abs_path
+
+def rgb2npy(image_array,filename,save_dir=None):
+    fmt = '.npy'
+    img = _rgb_to_fmt(image_array,filename,save_dir,fmt)
+    return img
+
+def rgb2jpg(image_array,filename,save_dir = None,exif_metadata = {}):
+    fmt = '.jpg'
+    img = _rgb_to_fmt(image_array,filename,save_dir,fmt)
+    return img
 
 
-YUV2RGB_JPEG      = np.array([[1.0,   1.0,   1.0  ], [0.0, -0.344, 1.772], [1.402, -0.714, 0.0]])
-YUV2RGB_SMPTE170M = np.array([[1.164, 1.164, 1.164], [0.0, -0.392, 2.017], [1.596, -0.813, 0.0]])
-YUV2RGB_REC709    = np.array([[1.164, 1.164, 1.164], [0.0, -0.213, 2.112], [1.793, -0.533, 0.0]])
+def rgb2png(image_array,filename,save_dir = None):
+    fmt = '.png'
+    img = _rgb_to_fmt(image_array,filename,save_dir,fmt)
+    return img
 
+def rgb2tif(image_array,filename,save_dir = None):
+    fmt = '.tif'
+    img = _rgb_to_fmt(image_array,filename,save_dir,fmt)
+    return img
 
 def YUV420_to_RGB(YUV_in, size, matrix=YUV2RGB_JPEG, rb_swap=True, final_width=0):
     """Convert a YUV420 image to an interleaved RGB image of half resolution. The

--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -1,4 +1,4 @@
-import picamera2
+import PiCamera2
 import selectors
 import threading
 import queue
@@ -7,7 +7,7 @@ import fcntl
 import mmap
 import select
 import time
-from picamera2.encoders.encoder import *
+from PiCamera2.encoders.encoder import *
 from v4l2 import *
 
 

--- a/picamera2/encoders/jpeg_encoder.py
+++ b/picamera2/encoders/jpeg_encoder.py
@@ -1,4 +1,4 @@
-from picamera2.encoders.multi_encoder import *
+from PiCamera2.encoders.multi_encoder import *
 import simplejpeg
 
 

--- a/picamera2/encoders/multi_encoder.py
+++ b/picamera2/encoders/multi_encoder.py
@@ -1,4 +1,4 @@
-from picamera2.encoders.encoder import *
+from PiCamera2.encoders.encoder import *
 import threading
 import queue
 from concurrent.futures import ThreadPoolExecutor

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -5,15 +5,15 @@ import libcamera
 import numpy as np
 import threading
 from PIL import Image
-from picamera2.encoders.encoder import Encoder
+from PiCamera2.encoders.encoder import Encoder
 import time
 import tempfile
 import json
-from picamera2.utils.picamera2_logger import *
-from picamera2.previews.null_preview import *
-from picamera2.previews.drm_preview import *
-from picamera2.previews.qt_preview import *
-from picamera2.previews.qt_gl_preview import *
+from PiCamera2.utils.PiCamera2_logger import *
+from PiCamera2.previews.null_preview import *
+from PiCamera2.previews.drm_preview import *
+from PiCamera2.previews.qt_preview import *
+from PiCamera2.previews.qt_gl_preview import *
 from enum import Enum
 import piexif
 
@@ -32,7 +32,7 @@ class Preview(Enum):
     QTGL = 3
 
 
-class Picamera2:
+class PiCamera2:
 
     """Welcome to the PiCamera2 class."""
 
@@ -1024,7 +1024,7 @@ class CompletedRequest:
             metadata = self.get_metadata()
             zero_ifd = {piexif.ImageIFD.Make: "Raspberry Pi",
                         piexif.ImageIFD.Model: self.picam2.camera.id,
-                        piexif.ImageIFD.Software: "Picamera2"}
+                        piexif.ImageIFD.Software: "PiCamera2"}
             total_gain = metadata["AnalogueGain"] * metadata["DigitalGain"]
             exif_ifd = {piexif.ExifIFD.ExposureTime: (metadata["ExposureTime"], 1000000),
                         piexif.ExifIFD.ISOSpeedRatings: int(total_gain * 100)}

--- a/picamera2/previews/drm_preview.py
+++ b/picamera2/previews/drm_preview.py
@@ -1,8 +1,8 @@
-import picamera2.picamera2
+import PiCamera2.PiCamera2
 import pykms
 import mmap
 import numpy as np
-from picamera2.previews.null_preview import *
+from PiCamera2.previews.null_preview import *
 
 dd = None
 

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -1,4 +1,4 @@
-import picamera2.picamera2
+import PiCamera2.PiCamera2
 import threading
 
 

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -24,7 +24,7 @@ from OpenGL.GLES3.VERSION.GLES3_3_0 import *
 
 from OpenGL.GL import shaders
 
-from picamera2.previews.gl_helpers import *
+from PiCamera2.previews.gl_helpers import *
 
 
 class EglState:
@@ -77,7 +77,7 @@ class EglState:
         eglMakeCurrent(self.display, EGL_NO_SURFACE, EGL_NO_SURFACE, self.context)
 
 
-class QGlPicamera2(QWidget):
+class QGlPiCamera2(QWidget):
     def __init__(self, picam2, parent=None, width=640, height=480):
         super().__init__(parent=parent)
         self.resize(width, height)
@@ -97,8 +97,8 @@ class QGlPicamera2(QWidget):
         # set_overlay could be called before the first frame arrives, hence:
         eglMakeCurrent(self.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)
 
-        self.picamera2 = picam2
-        self.camera_notifier = QSocketNotifier(self.picamera2.camera_manager.efd,
+        self.PiCamera2 = picam2
+        self.camera_notifier = QSocketNotifier(self.PiCamera2.camera_manager.efd,
                                                QtCore.QSocketNotifier.Read,
                                                self)
         self.camera_notifier.activated.connect(self.handle_requests)
@@ -281,15 +281,15 @@ class QGlPicamera2(QWidget):
     def repaint_with_lock(self, completed_request):
         eglMakeCurrent(self.egl.display, self.surface, self.surface, self.egl.context)
         if completed_request.request not in self.buffers:
-            if self.stop_count != self.picamera2.stop_count:
-                if self.picamera2.verbose_console:
+            if self.stop_count != self.PiCamera2.stop_count:
+                if self.PiCamera2.verbose_console:
                     print("Garbage collect", len(self.buffers), "textures")
                 for (req, buffer) in self.buffers.items():
                     glDeleteTextures(buffer.texture, 1)
                 self.buffers = {}
-                self.stop_count = self.picamera2.stop_count
+                self.stop_count = self.PiCamera2.stop_count
 
-            if self.picamera2.verbose_console:
+            if self.PiCamera2.verbose_console:
                 print("Make buffer for request", completed_request.request)
             self.buffers[completed_request.request] = self.Buffer(self.egl.display, completed_request)
 
@@ -313,9 +313,9 @@ class QGlPicamera2(QWidget):
 
     @pyqtSlot()
     def handle_requests(self):
-        request = self.picamera2.process_requests()
+        request = self.PiCamera2.process_requests()
         if request:
-            if self.picamera2.display_stream_name is not None:
+            if self.PiCamera2.display_stream_name is not None:
                 self.repaint(request)
             else:
                 request.release()

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -6,15 +6,15 @@ from PIL.ImageQt import ImageQt
 import numpy as np
 
 
-class QPicamera2(QWidget):
+class QPiCamera2(QWidget):
     def __init__(self, picam2, parent=None, width=640, height=480):
         super().__init__(parent=parent)
-        self.picamera2 = picam2
+        self.PiCamera2 = picam2
         self.label = QLabel(self)
         self.label.resize(width, height)
         self.overlay = None
         self.painter = QtGui.QPainter()
-        self.camera_notifier = QSocketNotifier(self.picamera2.camera_manager.efd,
+        self.camera_notifier = QSocketNotifier(self.PiCamera2.camera_manager.efd,
                                                QtCore.QSocketNotifier.Read,
                                                self)
         self.camera_notifier.activated.connect(self.handle_requests)
@@ -37,14 +37,14 @@ class QPicamera2(QWidget):
 
     @pyqtSlot()
     def handle_requests(self):
-        request = self.picamera2.process_requests()
+        request = self.PiCamera2.process_requests()
         if not request:
             return
 
-        if self.picamera2.display_stream_name is not None:
+        if self.PiCamera2.display_stream_name is not None:
             # This all seems horribly expensive. Pull request welcome if you know a better way!
             size = self.label.size()
-            img = request.make_image(self.picamera2.display_stream_name, size.width(), size.height())
+            img = request.make_image(self.PiCamera2.display_stream_name, size.width(), size.height())
             qim = ImageQt(img)
             self.painter.begin(qim)
             overlay = self.overlay

--- a/picamera2/previews/qt_gl_preview.py
+++ b/picamera2/previews/qt_gl_preview.py
@@ -1,4 +1,4 @@
-import picamera2.picamera2
+import PiCamera2.PiCamera2
 import threading
 import atexit
 
@@ -6,13 +6,13 @@ import atexit
 class QtGlPreview:
     def thread_func(self, picam2, width, height):
         # Running Qt in a thread other than the main thread is a bit tricky...
-        from picamera2.previews.q_gl_picamera2 import QApplication, QGlPicamera2
+        from PiCamera2.previews.q_gl_PiCamera2 import QApplication, QGlPiCamera2
 
         self.app = QApplication([])
         self.size = (width, height)
-        self.qpicamera2 = QGlPicamera2(picam2, width=width, height=height)
-        self.qpicamera2.setWindowTitle("QtGlPreview")
-        self.qpicamera2.show()
+        self.qPiCamera2 = QGlPiCamera2(picam2, width=width, height=height)
+        self.qPiCamera2.setWindowTitle("QtGlPreview")
+        self.qPiCamera2.show()
         picam2.asynchronous = True
         # Can't get Qt to exit tidily without this. Possibly an artifact of running
         # it in another thread?
@@ -22,9 +22,9 @@ class QtGlPreview:
         self.app.exec()
 
         atexit.unregister(self.stop)
-        self.qpicamera2.picamera2.asynchronous = False
+        self.qPiCamera2.PiCamera2.asynchronous = False
         # Again, all necessary to keep Qt quiet.
-        del self.qpicamera2
+        del self.qPiCamera2
         del self.app
 
     def __init__(self, width=640, height=480):
@@ -45,4 +45,4 @@ class QtGlPreview:
         self.thread.join()
 
     def set_overlay(self, overlay):
-        self.qpicamera2.set_overlay(overlay)
+        self.qPiCamera2.set_overlay(overlay)

--- a/picamera2/previews/qt_preview.py
+++ b/picamera2/previews/qt_preview.py
@@ -1,4 +1,4 @@
-import picamera2.picamera2
+import PiCamera2.PiCamera2
 import threading
 import atexit
 
@@ -6,13 +6,13 @@ import atexit
 class QtPreview:
     def thread_func(self, picam2, width, height):
         # Running Qt in a thread other than the main thread is a bit tricky...
-        from picamera2.previews.q_picamera2 import QApplication, QPicamera2
+        from PiCamera2.previews.q_PiCamera2 import QApplication, QPiCamera2
 
         self.app = QApplication([])
         self.size = (width, height)
-        self.qpicamera2 = QPicamera2(picam2, width=width, height=height)
-        self.qpicamera2.setWindowTitle("QtPreview")
-        self.qpicamera2.show()
+        self.qPiCamera2 = QPiCamera2(picam2, width=width, height=height)
+        self.qPiCamera2.setWindowTitle("QtPreview")
+        self.qPiCamera2.show()
         picam2.asynchronous = True
         # Can't get Qt to exit tidily without this. Possibly an artifact of running
         # it in another thread?
@@ -22,11 +22,11 @@ class QtPreview:
         self.app.exec()
 
         atexit.unregister(self.stop)
-        self.qpicamera2.picamera2.asynchronous = False
+        self.qPiCamera2.PiCamera2.asynchronous = False
         # Again, all necessary to keep Qt quiet.
-        del self.qpicamera2.label
-        del self.qpicamera2.camera_notifier
-        del self.qpicamera2
+        del self.qPiCamera2.label
+        del self.qPiCamera2.camera_notifier
+        del self.qPiCamera2
         del self.app
 
     def __init__(self, width=640, height=480):
@@ -47,4 +47,4 @@ class QtPreview:
         self.thread.join()
 
     def set_overlay(self, overlay):
-        self.qpicamera2.set_overlay(overlay)
+        self.qPiCamera2.set_overlay(overlay)

--- a/picamera2/utils/picamera2_logger.py
+++ b/picamera2/utils/picamera2_logger.py
@@ -11,7 +11,7 @@ Console Level Options
 
 
 def initialize_logger(console_level):
-    logger = logging.getLogger('picamera2')
+    logger = logging.getLogger('PiCamera2')
     logger.setLevel(logging.DEBUG)
     if not logger.handlers:
         console = logging.StreamHandler()

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -1,9 +1,9 @@
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 
 def main():
     print("With context...")
     time.sleep(1)
-    with Picamera2() as picam2:
+    with PiCamera2() as picam2:
         preview = picam2.preview_configuration()
         picam2.configure(preview)
         picam2.start()
@@ -15,7 +15,7 @@ def main():
     
     print("Without context...")
     time.sleep(1)
-    picam2 = Picamera2()
+    picam2 = PiCamera2()
     preview = picam2.preview_configuration()
     picam2.configure(preview)
     picam2.start()

--- a/tests/drm_preview_test.py
+++ b/tests/drm_preview_test.py
@@ -2,13 +2,13 @@
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
 preview_type = Preview.DRM
 
 print("First preview...")
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.configure(picam2.preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
@@ -17,7 +17,7 @@ picam2.close()
 print("Done")
 
 print("Second preview...")
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.configure(picam2.preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()

--- a/tests/preview_cycle_test.py
+++ b/tests/preview_cycle_test.py
@@ -1,4 +1,4 @@
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
 
@@ -8,7 +8,7 @@ buffer = 1
 def main():
 
     #First we create a camera instance.
-    picam2 = Picamera2()
+    picam2 = PiCamera2()
 
     #Let's set it up for previewing.
     preview = picam2.preview_configuration()

--- a/tests/preview_location_test.py
+++ b/tests/preview_location_test.py
@@ -1,8 +1,8 @@
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
 print("Preview re-initialized after start.")
-picam2 = Picamera2()
+picam2 = PiCamera2()
 preview = picam2.preview_configuration()
 picam2.configure(preview)
 picam2.start()
@@ -16,7 +16,7 @@ picam2.close()
 
 
 print("Preview initialized before start.")
-picam2 = Picamera2()
+picam2 = PiCamera2()
 preview = picam2.preview_configuration()
 picam2.configure(preview)
 picam2.start_preview(Preview.QT)

--- a/tests/qt_gl_preview_test.py
+++ b/tests/qt_gl_preview_test.py
@@ -2,13 +2,13 @@
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
 
-from picamera2.picamera2 import *
+from PiCamera2.PiCamera2 import *
 import time
 
 preview_type = Preview.QTGL
 
 print("First preview...")
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.configure(picam2.preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
@@ -17,7 +17,7 @@ picam2.close()
 print("Done")
 
 print("Second preview...")
-picam2 = Picamera2()
+picam2 = PiCamera2()
 picam2.configure(picam2.preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -15,24 +15,24 @@ import sys
 # folder and should be self-checking, returning a non-zero exit code if they
 # are deemed to have failed.
 #
-# The script assumes the Picamera2 code is in /home/pi/picamera2, the list
+# The script assumes the PiCamera2 code is in /home/pi/PiCamera2, the list
 # of tests to run is in tests/test_list.txt below that. The tests run in
-# the folder /home/pi/picamera2_tests where temporary files can be created,
+# the folder /home/pi/PiCamera2_tests where temporary files can be created,
 # and which are deleted before each test starts. These locations can be
 # altered with the options:
 #
-# -d - folder for temporary files where the tests run (default /home/pi/picamera2_tests)
-# -p - location where the picamera2 repository has been cloned (default /home/pi/picamera2)
+# -d - folder for temporary files where the tests run (default /home/pi/PiCamera2_tests)
+# -p - location where the PiCamera2 repository has been cloned (default /home/pi/PiCamera2)
 # -t - file listing tests to be run (default tests/test_list.txt)
 #
 # Within the test list file, entries should be one per line and give the
-# location under the picamera2 folder. Any individual test must take less
+# location under the PiCamera2 folder. Any individual test must take less
 # than 30 seconds, otherwise they will be deemed to have timed out.
 # Any line starting with # is ignored. The special value EOL is also
 # recognised, which stops the reading of any further tests from the file.
 
 
-def load_test_list(test_list_file, picamera2_dir):
+def load_test_list(test_list_file, PiCamera2_dir):
     tests = []
     with open(test_list_file, 'r') as f:
         for test in f:
@@ -40,7 +40,7 @@ def load_test_list(test_list_file, picamera2_dir):
             if test == "EOL":
                 break
             elif not test.startswith('#'):
-                tests.append(os.path.join(picamera2_dir, test))
+                tests.append(os.path.join(PiCamera2_dir, test))
     return tests
 
 
@@ -87,23 +87,23 @@ def run_tests(tests):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='picamera2 automated tests')
-    parser.add_argument('--dir', '-d', action='store', default='/home/pi/picamera2_tests',
+    parser = argparse.ArgumentParser(description='PiCamera2 automated tests')
+    parser.add_argument('--dir', '-d', action='store', default='/home/pi/PiCamera2_tests',
                         help='Folder in which to run tests')
-    parser.add_argument('--picamera2-dir', '-p', action='store', default='/home/pi/picamera2',
-                        help='Location of picamera2 folder')
+    parser.add_argument('--PiCamera2-dir', '-p', action='store', default='/home/pi/PiCamera2',
+                        help='Location of PiCamera2 folder')
     parser.add_argument('--test-list-file', '-t', action='store', default='tests/test_list.txt',
                         help='File containing list of tests to run')
     args = parser.parse_args()
 
     dir = args.dir
-    picamera2_dir = args.picamera2_dir
-    test_list_file = os.path.join(picamera2_dir, args.test_list_file)
+    PiCamera2_dir = args.PiCamera2_dir
+    test_list_file = os.path.join(PiCamera2_dir, args.test_list_file)
     print("dir:", dir)
-    print("Picamera2 dir:", picamera2_dir)
+    print("PiCamera2 dir:", PiCamera2_dir)
     print("Test list file:", test_list_file)
 
-    tests = load_test_list(test_list_file, picamera2_dir)
+    tests = load_test_list(test_list_file, PiCamera2_dir)
 
     if not os.path.exists(dir):
         os.makedirs(dir)


### PR DESCRIPTION
Taking a break from the mechanical design of my camera, so I should have more time to contribute in the future.

I was getting reduced size images when creating full size images on the IMX477. I changed align_stream to estimate the stream size to be high so that no pixels are lost.

The .npy is one of many ways to capture RGB values in a non-visual format. Will probably not be used by the majority of users, but is nice to have.

It might be worth it to move the converters back into picamera2.py and within the main class. Additions of metadata as exif and tiff tags could utilize some of the private information in the main class. This may require some reworking of some of the capture functions. The alternative is to require the user to explicitly pass metadata.

Signed-off-by: Ian Black <blackia@oregonstate.edu>