### PR TITLE
Add "#!/usr/bin/python" to the top of overlay examples

### DIFF
--- a/examples/overlay_drm.py
+++ b/examples/overlay_drm.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 from picamera2.picamera2 import *
 import numpy as np
 import time

--- a/examples/overlay_gl.py
+++ b/examples/overlay_gl.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 from picamera2.picamera2 import *
 import numpy as np
 import time

--- a/examples/overlay_null.py
+++ b/examples/overlay_null.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 from picamera2.picamera2 import *
 import numpy as np
 import time

--- a/examples/overlay_qt.py
+++ b/examples/overlay_qt.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 from picamera2.picamera2 import *
 import numpy as np
 import time


### PR DESCRIPTION
This means they can run directly without having to invoke the Python
interpreter explicitly (like the other examples).

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>