### PR TITLE
Add offset and window frame controls to preview windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ To use the Qt (non-GL) preview window, use `picam2.start_preview(Preview.QT)` in
 
 For no preview window at all, use `picam2.start_preview()` or `picam2.start_preview(Preview.NULL)`.
 
+Preview windows can be be assigned a particular location on the screen (`picam2.start_preview(Preview.QTGL, x=100, y=200)`).
+
 Please refer to the supplied examples for more information.
 
 ### Overlays

--- a/examples/window_offset.py
+++ b/examples/window_offset.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+# Create a preview window at a particular location on the display.
+
+from picamera2.picamera2 import *
+import time
+
+picam2 = Picamera2()
+picam2.start_preview(Preview.QTGL, x=100, y=200)
+
+preview_config = picam2.preview_configuration()
+picam2.configure(preview_config)
+
+picam2.start()
+time.sleep(2)

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -19,7 +19,7 @@ class NullPreview:
 
         picam2.asynchronous = False
 
-    def __init__(self, width=None, height=None):
+    def __init__(self, x=None, y=None, width=None, height=None):
         # Ignore width and height as they are meaningless. We only accept them so as to
         # be a drop-in replacement for the Qt/DRM previews.
         self.size = (width, height)

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -1,5 +1,5 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import pyqtSlot, QSocketNotifier
+from PyQt5.QtCore import pyqtSlot, QSocketNotifier, Qt
 from PyQt5.QtWidgets import QWidget, QApplication, QLabel
 from PIL import Image
 from PIL.ImageQt import ImageQt

--- a/picamera2/previews/qt_gl_preview.py
+++ b/picamera2/previews/qt_gl_preview.py
@@ -4,13 +4,15 @@ import atexit
 
 
 class QtGlPreview:
-    def thread_func(self, picam2, width, height):
+    def thread_func(self, picam2):
         # Running Qt in a thread other than the main thread is a bit tricky...
-        from picamera2.previews.q_gl_picamera2 import QApplication, QGlPicamera2
+        from picamera2.previews.q_gl_picamera2 import QApplication, QGlPicamera2, Qt
 
         self.app = QApplication([])
-        self.size = (width, height)
-        self.qpicamera2 = QGlPicamera2(picam2, width=width, height=height)
+        self.size = (self.width, self.height)
+        self.qpicamera2 = QGlPicamera2(picam2, width=self.width, height=self.height)
+        if self.x is not None and self.y is not None:
+            self.qpicamera2.move(self.x, self.y)
         self.qpicamera2.setWindowTitle("QtGlPreview")
         self.qpicamera2.show()
         picam2.asynchronous = True
@@ -27,14 +29,15 @@ class QtGlPreview:
         del self.qpicamera2
         del self.app
 
-    def __init__(self, width=640, height=480):
+    def __init__(self, x=None, y=None, width=640, height=480):
+        self.x = x
+        self.y = y
         self.width = width
         self.height = height
 
     def start(self, picam2):
         self.event = threading.Event()
-        self.thread = threading.Thread(target=self.thread_func,
-                                       args=(picam2, self.width, self.height))
+        self.thread = threading.Thread(target=self.thread_func, args=(picam2, ))
         self.thread.setDaemon(True)
         self.thread.start()
         self.event.wait()

--- a/picamera2/previews/qt_preview.py
+++ b/picamera2/previews/qt_preview.py
@@ -4,13 +4,15 @@ import atexit
 
 
 class QtPreview:
-    def thread_func(self, picam2, width, height):
+    def thread_func(self, picam2):
         # Running Qt in a thread other than the main thread is a bit tricky...
-        from picamera2.previews.q_picamera2 import QApplication, QPicamera2
+        from picamera2.previews.q_picamera2 import QApplication, QPicamera2, Qt
 
         self.app = QApplication([])
-        self.size = (width, height)
-        self.qpicamera2 = QPicamera2(picam2, width=width, height=height)
+        self.size = (self.width, self.height)
+        self.qpicamera2 = QPicamera2(picam2, width=self.width, height=self.height)
+        if self.x is not None and self.y is not None:
+            self.qpicamera2.move(self.x, self.y)
         self.qpicamera2.setWindowTitle("QtPreview")
         self.qpicamera2.show()
         picam2.asynchronous = True
@@ -29,14 +31,15 @@ class QtPreview:
         del self.qpicamera2
         del self.app
 
-    def __init__(self, width=640, height=480):
+    def __init__(self, x=None, y=None, width=640, height=480):
+        self.x = x
+        self.y = y
         self.width = width
         self.height = height
 
     def start(self, picam2):
         self.event = threading.Event()
-        self.thread = threading.Thread(target=self.thread_func,
-                                       args=(picam2, self.width, self.height))
+        self.thread = threading.Thread(target=self.thread_func, args=(picam2, ))
         self.thread.setDaemon(True)
         self.thread.start()
         self.event.wait()

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -20,6 +20,7 @@ examples/still_during_video.py
 examples/switch_mode.py
 examples/switch_mode_2.py
 examples/tuning_file.py
+examples/window_offset.py
 examples/zoom.py
 tests/context_test.py
 tests/preview_cycle_test.py


### PR DESCRIPTION
The Qt-based preview windows now have x and y parameters so that users
can force a particular offset. Also the "frameless" parameter allows
the window to appear without a surrounding frame. The previous
behaviour (with a frame) is preserved as the default.

An extra example of this and some extra documentation are also
provided.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>