### PR TITLE
Fix leak of OpenGL texture handles

### DIFF
--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -285,7 +285,7 @@ class QGlPicamera2(QWidget):
                 if self.picamera2.verbose_console:
                     print("Garbage collect", len(self.buffers), "textures")
                 for (req, buffer) in self.buffers.items():
-                    glDeleteTextures(buffer.texture, 1)
+                    glDeleteTextures(1, [buffer.texture])
                 self.buffers = {}
                 self.stop_count = self.picamera2.stop_count
 


### PR DESCRIPTION
The glDeleteTextures function was being called incorrectly, which is
actually rather easy to do, and was silently doing nothing. This
causes us gradually to run out of CMA.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>