### PR TITLE
Make the Qt signal/slot mechanism easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ This is a very simple *PyQt* application. It creates a camera preview widget tha
 
 We also use the `Picamera2` object's *request callback*, which is called whenever an image is about to be displayed in the preview pane. Here we just fetch the camera's current parameters (the *metadata*) and write all of the information to a text pane.
 
+There is a second version of this [app_capture2.py](examples/app_capture2.py) that is very similar but uses the Qt signal/slot mechanism to regain control when the capture operation is complete. Camera operations may not block the main Qt thread because that is the same thread that actually handles camera activity, so this would result in a deadlock.
+
 ### [capture_full_res.py](examples/capture_full_res.py)
 
 This application starts a preview window and then performs a full resolution JPEG capture. The preview normally uses one of the camera's faster readout modes, so we have to pick a separate *capture* mode, and *switch* to it, for the final capture.

--- a/examples/app_capture2.py
+++ b/examples/app_capture2.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+
+# This example is essentially the same as app_capture.py, however here
+# we use the Qt signal/slot mechanism to get a callback (capture_done)
+# when the capture, that is running asynchronously, is finished.
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtWidgets import *
+
+from picamera2.previews.q_gl_picamera2 import *
+from picamera2.picamera2 import *
+
+
+def request_callback(request):
+    label.setText(''.join("{}: {}\n".format(k, v) for k, v in request.get_metadata().items()))
+
+
+picam2 = Picamera2()
+picam2.request_callback = request_callback
+picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+
+app = QApplication([])
+
+
+def on_button_clicked():
+    button.setEnabled(False)
+    cfg = picam2.still_configuration()
+    picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False, signal_function=qpicamera2.signal_done)
+
+
+def capture_done():
+    button.setEnabled(True)
+
+
+qpicamera2 = QGlPicamera2(picam2, width=800, height=600)
+button = QPushButton("Click to capture JPEG")
+label = QLabel()
+window = QWidget()
+qpicamera2.done_signal.connect(capture_done)
+button.clicked.connect(on_button_clicked)
+
+label.setFixedWidth(400)
+label.setAlignment(QtCore.Qt.AlignTop)
+layout_h = QHBoxLayout()
+layout_v = QVBoxLayout()
+layout_v.addWidget(label)
+layout_v.addWidget(button)
+layout_h.addWidget(qpicamera2, 80)
+layout_h.addLayout(layout_v, 20)
+window.setWindowTitle("Qt Picamera2 App")
+window.resize(1200, 600)
+window.setLayout(layout_h)
+
+picam2.start()
+window.show()
+app.exec()

--- a/examples/app_capture_request.py
+++ b/examples/app_capture_request.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3
+
+# This example is similar to the app_capture2.py example, however here we
+# capture a request. The request is returned to us in the picamera2's
+# async_result field.
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtWidgets import *
+
+from picamera2.previews.q_picamera2 import *
+from picamera2.picamera2 import *
+
+
+def request_callback(request):
+    label.setText(''.join("{}: {}\n".format(k, v) for k, v in request.get_metadata().items()))
+
+
+picam2 = Picamera2()
+picam2.request_callback = request_callback
+picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+
+app = QApplication([])
+
+
+def on_button_clicked():
+    button.setEnabled(False)
+    picam2.capture_request(wait=False, signal_function=qpicamera2.signal_done)
+
+
+def capture_done():
+    # Here's the request we captured. But we must always release it when we're done with it!
+    print("Request:", picam2.async_result)
+    picam2.async_result.release()
+    button.setEnabled(True)
+
+
+qpicamera2 = QPicamera2(picam2, width=800, height=600)
+button = QPushButton("Click to capture")
+label = QLabel()
+window = QWidget()
+qpicamera2.done_signal.connect(capture_done)
+button.clicked.connect(on_button_clicked)
+
+label.setFixedWidth(400)
+label.setAlignment(QtCore.Qt.AlignTop)
+layout_h = QHBoxLayout()
+layout_v = QVBoxLayout()
+layout_v.addWidget(label)
+layout_v.addWidget(button)
+layout_h.addWidget(qpicamera2, 80)
+layout_h.addLayout(layout_v, 20)
+window.setWindowTitle("Qt Picamera2 App")
+window.resize(1200, 600)
+window.setLayout(layout_h)
+
+picam2.start()
+window.show()
+app.exec()

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -1,7 +1,7 @@
 from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtCore import pyqtSlot, QSocketNotifier
 from PyQt5.QtWidgets import QWidget, QApplication
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, pyqtSignal
 
 import sys
 import threading
@@ -74,6 +74,8 @@ class EglState:
 
 
 class QGlPicamera2(QWidget):
+    done_signal = pyqtSignal()
+
     def __init__(self, picam2, parent=None, width=640, height=480):
         super().__init__(parent=parent)
         self.resize(width, height)
@@ -112,6 +114,9 @@ class QGlPicamera2(QWidget):
         if self.current_request is not None:
             self.current_request.release()
             self.current_request = None
+
+    def signal_done(self, picamera2):
+        self.done_signal.emit()
 
     def paintEngine(self):
         return None

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -1,5 +1,5 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import pyqtSlot, QSocketNotifier, Qt
+from PyQt5.QtCore import pyqtSlot, QSocketNotifier, Qt, pyqtSignal
 from PyQt5.QtWidgets import QWidget, QApplication, QLabel
 from PIL import Image
 from PIL.ImageQt import ImageQt
@@ -7,6 +7,8 @@ import numpy as np
 
 
 class QPicamera2(QWidget):
+    done_signal = pyqtSignal()
+
     def __init__(self, picam2, parent=None, width=640, height=480):
         super().__init__(parent=parent)
         self.picamera2 = picam2
@@ -18,6 +20,9 @@ class QPicamera2(QWidget):
                                                QtCore.QSocketNotifier.Read,
                                                self)
         self.camera_notifier.activated.connect(self.handle_requests)
+
+    def signal_done(self, picamera2):
+        self.done_signal.emit()
 
     def set_overlay(self, overlay):
         if overlay is not None:

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+
+# Start a Qt application, and use an asynchronous thread to "click" on the GUI.
+
+import sys
+import time
+import threading
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtWidgets import *
+
+from picamera2.previews.q_gl_picamera2 import *
+from picamera2.picamera2 import *
+
+
+def request_callback(request):
+    label.setText(''.join("{}: {}\n".format(k, v) for k, v in request.get_metadata().items()))
+
+
+picam2 = Picamera2()
+picam2.request_callback = request_callback
+picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+
+app = QApplication([])
+
+
+def on_button_clicked():
+    button.setEnabled(False)
+    cfg = picam2.still_configuration()
+    picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False, signal_function=qpicamera2.signal_done)
+
+
+def capture_done():
+    button.setEnabled(True)
+
+
+qpicamera2 = QGlPicamera2(picam2, width=800, height=600)
+button = QPushButton("Click to capture JPEG")
+label = QLabel()
+window = QWidget()
+qpicamera2.done_signal.connect(capture_done)
+button.clicked.connect(on_button_clicked)
+
+label.setFixedWidth(400)
+label.setAlignment(QtCore.Qt.AlignTop)
+layout_h = QHBoxLayout()
+layout_v = QVBoxLayout()
+layout_v.addWidget(label)
+layout_v.addWidget(button)
+layout_h.addWidget(qpicamera2, 80)
+layout_h.addLayout(layout_v, 20)
+window.setWindowTitle("Qt Picamera2 App")
+window.resize(1200, 600)
+window.setLayout(layout_h)
+
+picam2.start()
+window.show()
+
+
+def test_func():
+    # This function can run in another thread and "click" on the GUI.
+    time.sleep(5)
+    button.clicked.emit()
+    time.sleep(5)
+    button.clicked.emit()
+    time.sleep(5)
+    app.quit()
+
+
+thread = threading.Thread(target=test_func, daemon=True)
+thread.start()
+
+app.exec()

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -22,6 +22,7 @@ examples/switch_mode_2.py
 examples/tuning_file.py
 examples/window_offset.py
 examples/zoom.py
+tests/app_test.py
 tests/context_test.py
 tests/preview_cycle_test.py
 tests/preview_location_test.py


### PR DESCRIPTION
Adding a "signal_done" function and corresponding signal to the Qt
widget classes makes it much more convenient to request a Qt callback
when a camera operation completes.

There's a new version of app_capture.py, app_capture2.py, that uses
this mechanism to re-enable the push button once the capture operation
is done.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>