### PR TITLE
Some previews hang on to the last request; they must release it when …

### DIFF
--- a/picamera2/previews/drm_preview.py
+++ b/picamera2/previews/drm_preview.py
@@ -121,6 +121,10 @@ class DrmPreview(NullPreview):
 
     def stop(self):
         super().stop()
+        # We may be hanging on to a request, return it to the camera system.
+        if self.current is not None:
+            self.current.release()
+            self.current = None
         # Seem to need some of this in order to be able to create another DrmPreview.
         self.drmfbs = {}
         self.overlay_new_fb = None

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -107,6 +107,10 @@ class QGlPicamera2(QWidget):
         del self.camera_notifier
         eglDestroySurface(self.egl.display, self.surface)
         self.surface = None
+        # We may be hanging on to a request, return it to the camera system.
+        if self.current_request is not None:
+            self.current_request.release()
+            self.current_request = None
 
     def paintEngine(self):
         return None


### PR DESCRIPTION
…stopped

Otherwise repeatedly stopping and re-starting the preview window will
"leak" requests, and eventually libcamera will run out. The affected
preview windows are the QtGl and DRM ones.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>