### PR TITLE
Change the default logging level

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -53,7 +53,7 @@ class Picamera2:
                     return json.load(fp)
         raise RuntimeError("Tuning file not found")
 
-    def __init__(self, camera_num=0, verbose_console=1, tuning=None):
+    def __init__(self, camera_num=0, verbose_console=None, tuning=None):
         """Initialise camera system and open the camera for use."""
         tuning_file = None
         if tuning is not None:
@@ -68,6 +68,8 @@ class Picamera2:
             os.environ.pop("LIBCAMERA_RPI_TUNING_FILE", None)  # Use default tuning
         self.camera_manager = libcamera.CameraManager.singleton()
         self.camera_idx = camera_num
+        if verbose_console is None:
+            verbose_console = int(os.environ.get('PICAMERA2_LOG_LEVEL', '0'))
         self.verbose_console = verbose_console
         self.log = initialize_logger(console_level=verbose_console)
         self._reset_flags()

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -43,10 +43,6 @@ class EglState:
 
         eglInitialize(self.display, major, minor)
 
-        print("EGL {} {}".format(
-            eglQueryString(self.display, EGL_VENDOR).decode(),
-            eglQueryString(self.display, EGL_VERSION).decode()))
-
         check_egl_extensions(self.display, ["EGL_EXT_image_dma_buf_import"])
 
         eglBindAPI(EGL_OPENGL_ES_API)
@@ -93,7 +89,12 @@ class QGlPicamera2(QWidget):
         self.current_request = None
         self.stop_count = 0
         self.egl = EglState()
+        if picam2.verbose_console:
+            print("EGL {} {}".format(
+                eglQueryString(self.egl.display, EGL_VENDOR).decode(),
+                eglQueryString(self.egl.display, EGL_VERSION).decode()))
         self.init_gl()
+
         # set_overlay could be called before the first frame arrives, hence:
         eglMakeCurrent(self.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)
 


### PR DESCRIPTION
The default logging level is set to zero (off). Actually it's now
taken from an environment variable (PICAMERA2_LOG_LEVEL) which defaults
to zero if not found.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>