### PR TITLE
WIP: Support for suggesting particular sensor modes

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -10,6 +10,7 @@ import time
 import tempfile
 import json
 from picamera2.utils.picamera2_logger import *
+from picamera2.sensors import *
 from picamera2.previews.null_preview import *
 from picamera2.previews.drm_preview import *
 from picamera2.previews.qt_preview import *
@@ -214,6 +215,16 @@ class Picamera2:
             self.stream_map = None
             self.log.info(f'Camera closed successfully.')
 
+    def list_sensor_modes(self):
+        """Return all the raw modes for that this sensor has."""
+        sensor = self.camera.id.split('/')[-1].split('@')[0]
+        return list_sensor_modes(sensor)
+
+    def get_sensor_mode(self, mode):
+        """Return a suggested raw mode for a given sensor use case."""
+        sensor = self.camera.id.split('/')[-1].split('@')[0]
+        return get_sensor_mode(sensor, mode)
+
     def make_initial_stream_config(self, stream_config, updates):
         # Take an initial stream_config and add any user updates.
         if updates is None:
@@ -231,6 +242,8 @@ class Picamera2:
         main = self.make_initial_stream_config({"format": "XBGR8888", "size": (640, 480)}, main)
         self.align_stream(main)
         lores = self.make_initial_stream_config({"format": "YUV420", "size": main["size"]}, lores)
+        if isinstance(raw, SensorMode):
+            raw = self.get_sensor_mode(raw)
         raw = self.make_initial_stream_config({"format": self.sensor_format, "size": main["size"]}, raw)
         controls = {"NoiseReductionMode": 3} | controls
         return {"use_case": "preview",

--- a/picamera2/sensors.py
+++ b/picamera2/sensors.py
@@ -1,0 +1,129 @@
+from enum import Enum
+
+# This file contains some utilities for finding out about sensors and manipulating
+# the reported sensor modes.
+
+
+class SensorMode(Enum):
+    """Enum to enable selecting specific types of sensor mode."""
+    FULL = 0
+    BINNED = 1
+    FAST = 2
+    PREVIEW = 3
+    _1080P = 4
+    _720P = 5
+
+
+def make_mode(format, size, crop, max_framerate, bit_depth):
+    return {"format": format,
+            "size": size,
+            "crop": crop,
+            "max_framerate": max_framerate,
+            "bit_depth": bit_depth}
+
+
+# We list all the mode details explicity as they are not all easily available. We're
+# happy to merge pull requests for other libcamera-supported sensors that users have.
+# There are two lists:
+# defined_sensor_modes lists the actual modes that the driver provides, and
+# recommended_sensor_modes maps a user's idea of the mode they want onto the ones
+# that the driver actually has.
+
+defined_sensor_modes = \
+    {'imx219':
+     {SensorMode.FULL:    make_mode('SBGGR10_CSI2P', (3280, 2464), (3280, 2464), 21.19,  10),
+      SensorMode.BINNED:  make_mode('SBGGR10_CSI2P', (1640, 1232), (3280, 2464), 41.56,  10),
+      SensorMode._1080P:  make_mode('SBGGR10_CSI2P', (1920, 1080), (1920, 1080), 41.85,  10),
+      SensorMode.FAST:    make_mode('SBGGR10_CSI2P', (640, 480),   (1280, 960),  59.85,  10)},
+     'imx477':
+     {SensorMode.FULL:    make_mode('SBGGR12_CSI2P', (4056, 3040), (4056, 3040), 10.00,  12),
+      SensorMode.BINNED:  make_mode('SBGGR12_CSI2P', (2028, 1520), (4056, 3040), 40.00,  12),
+      SensorMode._1080P:  make_mode('SBGGR12_CSI2P', (2028, 1080), (4056, 2160), 50.02,  12),
+      SensorMode.FAST:    make_mode('SBGGR10_CSI2P', (1332, 990),  (2664, 1980), 120.03, 10)},
+     'ov5647':
+     {SensorMode.FULL:    make_mode('SGBRG10_CSI2P', (2592, 1944), (2592, 1944), 15.63,  10),
+      SensorMode.BINNED:  make_mode('SGBRG10_CSI2P', (1296, 972),  (2592, 1944), 43.25,  10),
+      SensorMode._1080P:  make_mode('SGBRG10_CSI2P', (1920, 1080), (1920, 1080), 30.62,  10),
+      SensorMode.FAST:    make_mode('SGBRG10_CSI2P', (640, 480),   (2560, 1920), 62.49,  10)}}
+
+recommended_sensor_modes = \
+    {'imx219':
+     {SensorMode.FULL:    SensorMode.FULL,
+      SensorMode.FAST:    SensorMode.FAST,
+      SensorMode.PREVIEW: SensorMode.BINNED,
+      SensorMode._1080P:  SensorMode._1080P,
+      SensorMode._720P:   SensorMode.BINNED},
+     'imx477':
+     {SensorMode.FULL:    SensorMode.FULL,
+      SensorMode.FAST:    SensorMode.FAST,
+      SensorMode.PREVIEW: SensorMode.BINNED,
+      SensorMode._1080P:  SensorMode._1080P,
+      SensorMode._720P:   SensorMode._1080P},
+     'ov5647':
+     {SensorMode.FULL:    SensorMode.FULL,
+      SensorMode.FAST:    SensorMode.FAST,
+      SensorMode.PREVIEW: SensorMode.BINNED,
+      SensorMode._1080P:  SensorMode._1080P,
+      SensorMode._720P:   SensorMode.BINNED}}
+
+
+def list_sensor_modes(sensor):
+    """Return all the defined modes for a sensor."""
+    if sensor not in defined_sensor_modes:
+        raise RuntimeError(f"Sensor '{sensor}' not in sensor database")
+    return defined_sensor_modes[sensor]
+
+
+def get_sensor_mode(sensor, mode):
+    """Return a suggested sensor mode."""
+    return list_sensor_modes(sensor)[recommended_sensor_modes[sensor][mode]].copy()
+
+
+class BayerOrder(Enum):
+    """Enum to represet a specific Bayer order."""
+    RGGB = 0
+    GRBG = 1
+    BGGR = 2
+    GBRG = 3
+    MONO = 4
+
+    def hflip(self):
+        """Horizontally flip the Bayer pattern."""
+        return BayerOrder.MONO if self == BayerOrder.MONO else BayerOrder(self.value ^ 1)
+
+    def vflip(self):
+        """Vertically flip the Bayer pattern."""
+        return BayerOrder.MONO if self == BayerOrder.MONO else BayerOrder(self.value ^ 2)
+
+
+def make_sensor_format(format_string):
+    """Utility to parse the libcamera sensor format string into useful parts."""
+    parsed = {}
+    for order in BayerOrder:
+        if order.name in format_string:
+            parsed['order'] = order
+            break
+    for bit_depth in (8, 10, 12, 14):
+        if str(bit_depth) in format_string:
+            parsed['bit_depth'] = bit_depth
+            break
+    parsed['packed'] = 'CSI2P' in format_string
+    return parsed
+
+
+def sensor_format_name(sensor_format):
+    """Utility to turn a parsed sensor format into a libcamera sensor format string."""
+    order = sensor_format['order'].name
+    bit_depth = sensor_format['bit_depth']
+    packed = '_CSI2P' if sensor_format['packed'] else ''
+    return f"S{order}{bit_depth}{packed}"
+
+
+def update_format_string(format_string, updates={}):
+    """Update a sensor format string by overwriting some of its implied fields."""
+    return sensor_format_name(make_sensor_format(format_string) | updates)
+
+
+def update_sensor_mode_format(mode, format_updates={}):
+    """Update the format string of a sensor mode by overwriting some of its implied fields."""
+    mode['format'] = update_format_string(mode['format'], format_updates)


### PR DESCRIPTION
Not sure about this functionality. I'd like it to be easier for applications to use and manipulate sensor modes, but is this helpful? It would enable things like:
```
config = picam2.preview_configuration(raw=SensorMode.FULL)
picam2.configure(config)
```
or
```
config = picam2.still_configuration(raw={})
update_sensor_mode_format(config['raw'], {'packed': False})
picam2.configure(config)
```
@naushir Do you think there are any other useful features we could add? Do you think we could do any of this better?