### PR TITLE
Display encode improvements

### DIFF
--- a/examples/still_during_video.py
+++ b/examples/still_during_video.py
@@ -11,9 +11,8 @@ picam2 = Picamera2()
 half_resolution = [dim // 2 for dim in picam2.sensor_resolution]
 main_stream = {"size": half_resolution}
 lores_stream = {"size": (640, 480)}
-video_config = picam2.video_configuration(main_stream, lores_stream)
+video_config = picam2.video_configuration(main_stream, lores_stream, encode="lores")
 picam2.configure(video_config)
-picam2.encode_stream_name = "lores"
 
 picam2.start_preview()
 encoder = H264Encoder(10000000)

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -94,6 +94,7 @@ class Picamera2:
         self.stream_map = None
         self.started = False
         self.stop_count = 0
+        self.configure_count = 0
         self.frames = 0
         self.functions = []
         self.event = threading.Event()
@@ -506,6 +507,7 @@ class Picamera2:
         # Mark ourselves as configured.
         self.libcamera_config = libcamera_config
         self.camera_config = camera_config
+        self.configure_count += 1
 
     def configure(self, camera_config=None):
         """Configure the camera system with the given configuration."""
@@ -632,9 +634,9 @@ class Picamera2:
             while len(self.completed_requests) > 1:
                 self.completed_requests.pop(0).release()
 
-        # If one of the functions we ran stopped the camera, then we don't want
-        # this going back to the application.
-        if display_request.stop_count != self.stop_count:
+        # If one of the functions we ran reconfigured the camera since this request came out,
+        # then we don't want it going back to the application as the memory is not valid.
+        if display_request.configure_count != self.configure_count:
             display_request.release()
             display_request = None
 
@@ -947,6 +949,7 @@ class CompletedRequest:
         self.lock = threading.Lock()
         self.picam2 = picam2
         self.stop_count = picam2.stop_count
+        self.configure_count = picam2.configure_count
 
     def acquire(self):
         """Acquire a reference to this completed request, which stops it being recycled back to


### PR DESCRIPTION
A couple of minor-ish improvements to how we decide what to display for preview and what to encode.

The first patch lets you name the streams that you want to display and encode in the configuration structure, for example if you wanted to encode the "main" stream but display the "lores" one you could do:
```
config = picam2.video_configuration(lores={'size': (640, 360)}, display='lores')
```
It's also better because remembering the camera configuration, for example to restore it later, now captures these extra elements of the system's state.

The second patch fixes a small inaccuracy in deciding whether it's safe to display a buffer. It's reconfiguring the camera, not stopping it, that invalidates the buffer, so the previous behaviour was slightly over-pessimistic.