### PR TITLE
Optimise memory for still capture

### DIFF
--- a/examples/capture_dng_and_jpeg.py
+++ b/examples/capture_dng_and_jpeg.py
@@ -9,7 +9,7 @@ picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
 preview_config = picam2.preview_configuration()
-capture_config = picam2.still_configuration(raw={})
+capture_config = picam2.still_configuration(raw={}, display=None)
 picam2.configure(preview_config)
 
 picam2.start()


### PR DESCRIPTION
The defaults for the still_configuration() method have been changed to
allocate much less memory, which is particularly beneficial for non Pi
4 devices. In particular, the format defaults to 24bpp rather than
32bpp, and the buffer_count to 1 (previously 2).

This latter change has required a few tweaks so that things work
better with a single buffer. We no longer hold on to the "last
request" as that would hang the pipeline completely, and the QtGl and
DRM previews avoid hanging on to the last buffer too. This probably
isn't ideal and hanging on to the last buffer is preferred, but in
practice everything appears to work and the alternative would (again)
be to hang the pipeline completely.

The only downside I see is that the new default 24bpp format isn't
supported by the QtGl preview, but I don't think this is a very
critical use case, and it's easy just to change it. Also better
throughput would be achieved for burst captures by increasing the
buffer_count to 2 (or even better, 3), but that's only viable if you
have the memory to spare.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>