### PR TITLE
Async Cleanup

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -99,7 +99,6 @@ class Picamera2:
         self.frames = 0
         self.functions = []
         self.event = threading.Event()
-        self.asynchronous = False
         self.async_operation_in_progress = False
         self.asyc_result = None
         self.async_error = None
@@ -110,6 +109,11 @@ class Picamera2:
         self.request_callback = None
         self.completed_requests = []
         self.lock = threading.Lock()  # protects the functions and completed_requests fields
+
+    @property
+    def asynchronous(self) -> bool:
+        """True if there is threaded operation."""
+        return self._preview is not None and getattr(self._preview, "thread", None) is not None and self._preview.thread.is_alive()
 
     def __enter__(self):
         return self

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -6,7 +6,6 @@ class NullPreview:
     def thread_func(self, picam2):
         import selectors
 
-        picam2.asynchronous = True
         sel = selectors.DefaultSelector()
         sel.register(picam2.camera_manager.efd, selectors.EVENT_READ, self.handle_request)
         self.event.set()
@@ -17,7 +16,6 @@ class NullPreview:
                 callback = key.data
                 callback(picam2)
 
-        picam2.asynchronous = False
 
     def __init__(self, x=None, y=None, width=None, height=None):
         # Ignore width and height as they are meaningless. We only accept them so as to

--- a/picamera2/previews/qt_gl_preview.py
+++ b/picamera2/previews/qt_gl_preview.py
@@ -15,7 +15,6 @@ class QtGlPreview:
             self.qpicamera2.move(self.x, self.y)
         self.qpicamera2.setWindowTitle("QtGlPreview")
         self.qpicamera2.show()
-        picam2.asynchronous = True
         # Can't get Qt to exit tidily without this. Possibly an artifact of running
         # it in another thread?
         atexit.register(self.stop)
@@ -24,7 +23,6 @@ class QtGlPreview:
         self.app.exec()
 
         atexit.unregister(self.stop)
-        self.qpicamera2.picamera2.asynchronous = False
         # Again, all necessary to keep Qt quiet.
         del self.qpicamera2
         del self.app

--- a/picamera2/previews/qt_preview.py
+++ b/picamera2/previews/qt_preview.py
@@ -15,7 +15,6 @@ class QtPreview:
             self.qpicamera2.move(self.x, self.y)
         self.qpicamera2.setWindowTitle("QtPreview")
         self.qpicamera2.show()
-        picam2.asynchronous = True
         # Can't get Qt to exit tidily without this. Possibly an artifact of running
         # it in another thread?
         atexit.register(self.stop)
@@ -24,7 +23,6 @@ class QtPreview:
         self.app.exec()
 
         atexit.unregister(self.stop)
-        self.qpicamera2.picamera2.asynchronous = False
         # Again, all necessary to keep Qt quiet.
         del self.qpicamera2.label
         del self.qpicamera2.camera_notifier


### PR DESCRIPTION
Setting attributed on parent objects is kinda confusing, so I think this makes the control flow a little cleaner and more robust generally.