### PR TITLE
Added controls functionality.

### DIFF
--- a/examples/capture_headless.py
+++ b/examples/capture_headless.py
@@ -1,4 +1,4 @@
-#!//usr/bin/python3
+#!/usr/bin/python3
 
 from picamera2.picamera2 import *
 

--- a/examples/exposure_fixed.py
+++ b/examples/exposure_fixed.py
@@ -11,5 +11,6 @@ picam2.start_preview(Preview.QTGL)
 preview_config = picam2.preview_configuration()
 picam2.configure(preview_config)
 
-picam2.start({"ExposureTime": 10000, "AnalogueGain": 1.0})
+picam2.set_controls({"ExposureTime": 10000, "AnalogueGain": 1.0})
+picam2.start()
 time.sleep(5)

--- a/examples/notebooks/controls_example.ipynb
+++ b/examples/notebooks/controls_example.ipynb
@@ -16,7 +16,11 @@
     "`pip install jupyter`\n",
     "\n",
     "Then to run it, simply enter `jupyter-notebook` into the Raspberry Pi terminal\n",
-    "and then navigate the `picamera2/examples/notebooks` folder to find this notebook.\n"
+    "and then navigate the `picamera2/examples/notebooks` folder to find this notebook.\n",
+    "\n",
+    "Note: If running in chromium, you may see better performance by turning off hardware acceleration in the chromium settings.\n",
+    "\n",
+    "***"
    ]
   },
   {
@@ -43,11 +47,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[0:18:18.889055277] [1775]  INFO Camera camera_manager.cpp:293 libcamera v0.0.0+3548-a11d63f9\n",
-      "[0:18:18.926675706] [1789]  WARN CameraSensorProperties camera_sensor_properties.cpp:163 No static properties available for 'imx477'\n",
-      "[0:18:18.926714539] [1789]  WARN CameraSensorProperties camera_sensor_properties.cpp:165 Please consider updating the camera sensor properties database\n",
-      "[0:18:18.926733834] [1789] ERROR CameraSensor camera_sensor.cpp:591 'imx477 10-001a': Camera sensor does not support test pattern modes.\n",
-      "[0:18:18.944477746] [1789]  INFO RPI raspberrypi.cpp:1352 Registered camera /base/soc/i2c0mux/i2c@1/imx477@1a to Unicam device /dev/media2 and ISP device /dev/media0\n"
+      "[0:34:16.617762579] [2959]  INFO Camera camera_manager.cpp:293 libcamera v0.0.0+3548-a11d63f9\n",
+      "[0:34:16.654798576] [2973]  WARN CameraSensorProperties camera_sensor_properties.cpp:163 No static properties available for 'imx477'\n",
+      "[0:34:16.654838353] [2973]  WARN CameraSensorProperties camera_sensor_properties.cpp:165 Please consider updating the camera sensor properties database\n",
+      "[0:34:16.654857408] [2973] ERROR CameraSensor camera_sensor.cpp:591 'imx477 10-001a': Camera sensor does not support test pattern modes.\n",
+      "[0:34:16.672082007] [2973]  INFO RPI raspberrypi.cpp:1352 Registered camera /base/soc/i2c0mux/i2c@1/imx477@1a to Unicam device /dev/media0 and ISP device /dev/media1\n"
      ]
     }
    ],
@@ -109,7 +113,7 @@
     {
      "data": {
       "text/plain": [
-       "{'Contrast': 1, 'Sharpness': 1, 'NoiseReductionMode': 2}"
+       "{'Contrast': 1, 'NoiseReductionMode': 2, 'Sharpness': 1}"
       ]
      },
      "execution_count": 3,
@@ -145,7 +149,7 @@
     {
      "data": {
       "text/plain": [
-       "{'Contrast': 0, 'Sharpness': 0, 'NoiseReductionMode': 1}"
+       "{'Contrast': 0, 'NoiseReductionMode': 1, 'Sharpness': 0}"
       ]
      },
      "execution_count": 4,
@@ -337,20 +341,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[0:18:19.167344748] [1775]  INFO Camera camera.cpp:1029 configuring streams: (0) 640x480-XBGR8888\n",
-      "[0:18:19.167802369] [1789]  INFO RPI raspberrypi.cpp:760 Sensor: /base/soc/i2c0mux/i2c@1/imx477@1a - Selected sensor format: 2028x1520-SBGGR12_1X12 - Selected unicam format: 2028x1520-pBCC\n",
-      "[0:18:20.939766348] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: NoiseReductionMode = 2\n",
+      "[0:34:16.956843993] [2959]  INFO Camera camera.cpp:1029 configuring streams: (0) 640x480-XBGR8888\n",
+      "[0:34:16.957354094] [2973]  INFO RPI raspberrypi.cpp:760 Sensor: /base/soc/i2c0mux/i2c@1/imx477@1a - Selected sensor format: 2028x1520-SBGGR12_1X12 - Selected unicam format: 2028x1520-pBCC\n",
+      "[0:34:18.716795921] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: NoiseReductionMode = 2\n",
       "qt.qpa.xcb: QXcbConnection: XCB error: 148 (Unknown), sequence: 192, resource id: 0, major code: 140 (Unknown), minor code: 20\n"
      ]
     }
    ],
    "source": [
     "picam2.controls.clear #You may not need this. It only clears the controls BEFORE the camera is started.\n",
-    "picam2.controls.NoiseReductionMode = 1\n",
-    "\n",
     "picam2.configure(picam2.preview_configuration())\n",
+    "picam2.controls.NoiseReductionMode = 2  #Need to put it after camera configuration because of how preview_configuration is built.\n",
     "picam2.start_preview(Preview.QTGL)\n",
-    "picam2.start()\n"
+    "picam2.start()"
    ]
   },
   {
@@ -380,38 +383,28 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[0:18:22.053895820] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: NoiseReductionMode = 2\n",
-      "[0:18:22.053950115] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.050000\n",
-      "[0:18:22.723722336] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.100000\n",
-      "[0:18:24.012997749] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.150000\n",
-      "[0:18:25.005245387] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.200000\n",
-      "[0:18:26.004152116] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.250000\n",
-      "[0:18:27.003592425] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.300000\n",
-      "[0:18:28.005935804] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.350000\n",
-      "[0:18:29.005101668] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.400000\n",
-      "[0:18:30.005799037] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.450000\n",
-      "[0:18:31.006512346] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.500000\n",
-      "[0:18:32.004173359] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.550000\n",
-      "[0:18:33.004429837] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.600000\n",
-      "[0:18:34.003704552] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.650000\n",
-      "[0:18:35.004224111] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.700000\n",
-      "[0:18:36.004944291] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.750000\n",
-      "[0:18:37.005849057] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.800000\n",
-      "[0:18:38.004842984] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.850000\n",
-      "[0:18:39.004907479] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.900000\n",
-      "[0:18:40.004485776] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.950000\n",
-      "[0:18:41.004951255] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 1.000000\n"
+      "[0:34:19.611754743] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: NoiseReductionMode = 2\n",
+      "[0:34:19.611806260] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.050000\n",
+      "[0:34:20.378173172] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.100000\n",
+      "[0:34:22.006727551] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.150000\n",
+      "[0:34:23.004325762] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.200000\n",
+      "[0:34:24.005638396] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.250000\n",
+      "[0:34:25.003287638] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.300000\n",
+      "[0:34:26.003332757] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.350000\n",
+      "[0:34:27.003684182] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.400000\n",
+      "[0:34:28.003653242] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.450000\n",
+      "[0:34:29.003172606] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.500000\n",
+      "[0:34:30.004648318] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.550000\n",
+      "[0:34:31.003679261] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.600000\n",
+      "[0:34:32.003941826] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.650000\n",
+      "[0:34:33.003280796] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.700000\n",
+      "[0:34:34.003373360] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.750000\n",
+      "[0:34:35.003676102] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.800000\n",
+      "[0:34:36.005282151] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.850000\n",
+      "[0:34:37.004864718] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.900000\n",
+      "[0:34:38.003765667] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.950000\n",
+      "[0:34:39.003817424] [2980]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 1.000000\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -423,32 +416,6 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Then to check the current controls we can use the `current` function."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "picam2.controls.current"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "pycharm": {
      "name": "#%% md\n"
@@ -457,13 +424,38 @@
    "source": [
     "## Current Settings\n",
     "\n",
-    "After the settings that you assign are passed to the camera, the Controls()\n",
+    "After the settings that you assign are passed to the camera, the `Controls`\n",
     "class is effectively reset so that there is no risk of repetition. However,\n",
-    "the Controls() class does keep track of the current settings of the camera.\n",
+    "it does keep track of the current settings of the camera.\n",
     "The current settings are always the settings that you last sent to the camera and that were accepted.\n",
     "\n",
     "If we look at the current settings now, we should see that the NoiseReductionMode is set to 2\n",
     "and the Brightness is 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Brightness': 1.0, 'NoiseReductionMode': 2}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picam2.stop_preview()\n",
+    "picam2.controls.current"
    ]
   },
   {
@@ -476,8 +468,8 @@
    "source": [
     "## Resetting Controls (in development)\n",
     "\n",
-    "If you wanted to reset the controls to what they were when you first turned on the camera,\n",
-    "you can issue the `reset` command. But first, we need to find out what the default controls were. If you compare it to the `ranges` function in the following cell, you may notice that some values are 0 when the 0 is technically outside the limits. This just means that the camera is handling these internally or in an automatic mode."
+    "If you wanted to reset the controls to what they were when you first turned on the camera (i.e. the defaults),\n",
+    "you can issue the `reset` command, which retains the default controls when `Picamera2` was instantiated. If you compare the libcamera output of the `reset` function to the `ranges` function, you may notice that some values are 0 when the 0 is technically outside the limits. This just means that the camera is handling these internally or in an automatic mode."
    ]
   },
   {
@@ -492,24 +484,24 @@
     {
      "data": {
       "text/plain": [
-       "{'FrameDurationLimits': [0, 0],\n",
-       " 'ColourCorrectionMatrix': [0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       " 'NoiseReductionMode': 0,\n",
-       " 'Contrast': 1.0,\n",
-       " 'AwbMode': 0,\n",
-       " 'ScalerCrop': (0, 0, 0, 0),\n",
-       " 'AwbEnable': 0,\n",
-       " 'ExposureValue': 0.0,\n",
-       " 'ColourGains': [0, 0],\n",
+       "{'AeConstraintMode': 0,\n",
+       " 'AeEnable': 0,\n",
        " 'AeExposureMode': 0,\n",
-       " 'Sharpness': 1.0,\n",
-       " 'Brightness': 0.0,\n",
-       " 'AeConstraintMode': 0,\n",
        " 'AeMeteringMode': 0,\n",
        " 'AnalogueGain': 0,\n",
-       " 'Saturation': 1.0,\n",
+       " 'AwbEnable': 0,\n",
+       " 'AwbMode': 0,\n",
+       " 'Brightness': 0.0,\n",
+       " 'ColourCorrectionMatrix': [0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+       " 'ColourGains': [0, 0],\n",
+       " 'Contrast': 1.0,\n",
        " 'ExposureTime': 0,\n",
-       " 'AeEnable': 0}"
+       " 'ExposureValue': 0.0,\n",
+       " 'FrameDurationLimits': [0, 0],\n",
+       " 'NoiseReductionMode': 0,\n",
+       " 'Saturation': 1.0,\n",
+       " 'ScalerCrop': (0, 0, 0, 0),\n",
+       " 'Sharpness': 1.0}"
       ]
      },
      "execution_count": 12,
@@ -533,24 +525,24 @@
     {
      "data": {
       "text/plain": [
-       "{'AeEnable': 0,\n",
-       " 'AeMeteringMode': 0,\n",
-       " 'AeConstraintMode': 0,\n",
+       "{'AeConstraintMode': 0,\n",
+       " 'AeEnable': 0,\n",
        " 'AeExposureMode': 0,\n",
-       " 'ExposureValue': 0.0,\n",
-       " 'ExposureTime': 0,\n",
+       " 'AeMeteringMode': 0,\n",
        " 'AnalogueGain': 0,\n",
-       " 'Brightness': 0.0,\n",
-       " 'Contrast': 1.0,\n",
        " 'AwbEnable': 0,\n",
        " 'AwbMode': 0,\n",
-       " 'ColourGains': [0, 0],\n",
-       " 'Saturation': 1.0,\n",
-       " 'Sharpness': 1.0,\n",
+       " 'Brightness': 0.0,\n",
        " 'ColourCorrectionMatrix': [0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
-       " 'ScalerCrop': (0, 0, 0, 0),\n",
+       " 'ColourGains': [0, 0],\n",
+       " 'Contrast': 1.0,\n",
+       " 'ExposureTime': 0,\n",
+       " 'ExposureValue': 0.0,\n",
        " 'FrameDurationLimits': [0, 0],\n",
-       " 'NoiseReductionMode': 0}"
+       " 'NoiseReductionMode': 0,\n",
+       " 'Saturation': 1.0,\n",
+       " 'ScalerCrop': (0, 0, 0, 0),\n",
+       " 'Sharpness': 1.0}"
       ]
      },
      "execution_count": 13,
@@ -559,7 +551,7 @@
     }
    ],
    "source": [
-    "picam2.controls.reset #Read only. Accepts no inputs.\n",
+    "picam2.controls.reset #Resets the camera to the controls it had when it was first turned on. Read only. Accepts no inputs.\n",
     "picam2.controls.config"
    ]
   },
@@ -583,7 +575,7 @@
    },
    "source": [
     "## Control Ranges (in development)\n",
-    "To get an idea of the valid ranges for each control, you can use the ranges function."
+    "To get an idea of the valid ranges for each control, you can query the ranges."
    ]
   },
   {
@@ -598,24 +590,24 @@
     {
      "data": {
       "text/plain": [
-       "{'FrameDurationLimits': {'min': 1000, 'max': 1000000000},\n",
-       " 'ColourCorrectionMatrix': {'min': -16.0, 'max': 16.0},\n",
-       " 'NoiseReductionMode': {'min': 0, 'max': 4},\n",
-       " 'Contrast': {'min': 0.0, 'max': 32.0},\n",
-       " 'AwbMode': {'min': 0, 'max': 7},\n",
-       " 'ScalerCrop': {'min': (0, 0, 0, 0), 'max': (65535, 65535, 65535, 65535)},\n",
-       " 'AwbEnable': {'min': False, 'max': True},\n",
-       " 'ExposureValue': {'min': -8.0, 'max': 8.0},\n",
-       " 'ColourGains': {'min': 0.0, 'max': 32.0},\n",
+       "{'AeConstraintMode': {'min': 0, 'max': 3},\n",
+       " 'AeEnable': {'min': False, 'max': True},\n",
        " 'AeExposureMode': {'min': 0, 'max': 3},\n",
-       " 'Sharpness': {'min': 0.0, 'max': 16.0},\n",
-       " 'Brightness': {'min': -1.0, 'max': 1.0},\n",
-       " 'AeConstraintMode': {'min': 0, 'max': 3},\n",
        " 'AeMeteringMode': {'min': 0, 'max': 3},\n",
        " 'AnalogueGain': {'min': 1.0, 'max': 32.0},\n",
-       " 'Saturation': {'min': 0.0, 'max': 32.0},\n",
+       " 'AwbEnable': {'min': False, 'max': True},\n",
+       " 'AwbMode': {'min': 0, 'max': 7},\n",
+       " 'Brightness': {'min': -1.0, 'max': 1.0},\n",
+       " 'ColourCorrectionMatrix': {'min': -16.0, 'max': 16.0},\n",
+       " 'ColourGains': {'min': 0.0, 'max': 32.0},\n",
+       " 'Contrast': {'min': 0.0, 'max': 32.0},\n",
        " 'ExposureTime': {'min': 0, 'max': 999999},\n",
-       " 'AeEnable': {'min': False, 'max': True}}"
+       " 'ExposureValue': {'min': -8.0, 'max': 8.0},\n",
+       " 'FrameDurationLimits': {'min': 1000, 'max': 1000000000},\n",
+       " 'NoiseReductionMode': {'min': 0, 'max': 4},\n",
+       " 'Saturation': {'min': 0.0, 'max': 32.0},\n",
+       " 'ScalerCrop': {'min': (0, 0, 0, 0), 'max': (65535, 65535, 65535, 65535)},\n",
+       " 'Sharpness': {'min': 0.0, 'max': 16.0}}"
       ]
      },
      "execution_count": 14,
@@ -629,31 +621,28 @@
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## End of Example"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## End of Example"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "outputs": [],
-   "source": [
-    "picam2.stop_preview()\n",
-    "picam2.stop()\n",
-    "picam2.close()"
-   ],
+   "execution_count": 15,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "picam2.stop()\n",
+    "picam2.close()"
+   ]
   }
  ],
  "metadata": {

--- a/examples/notebooks/controls_example.ipynb
+++ b/examples/notebooks/controls_example.ipynb
@@ -1,0 +1,680 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Controls Example\n",
+    "\n",
+    "If you want to run this notebook on your Raspberry Pi, but don't have Jupyter Notebook, you can install it with `pip`.\n",
+    "\n",
+    "`pip install jupyter`\n",
+    "\n",
+    "Then to run it, simply enter `jupyter-notebook` into the Raspberry Pi terminal\n",
+    "and then navigate the `picamera2/examples/notebooks` folder to find this notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[0:18:18.889055277] [1775]  INFO Camera camera_manager.cpp:293 libcamera v0.0.0+3548-a11d63f9\n",
+      "[0:18:18.926675706] [1789]  WARN CameraSensorProperties camera_sensor_properties.cpp:163 No static properties available for 'imx477'\n",
+      "[0:18:18.926714539] [1789]  WARN CameraSensorProperties camera_sensor_properties.cpp:165 Please consider updating the camera sensor properties database\n",
+      "[0:18:18.926733834] [1789] ERROR CameraSensor camera_sensor.cpp:591 'imx477 10-001a': Camera sensor does not support test pattern modes.\n",
+      "[0:18:18.944477746] [1789]  INFO RPI raspberrypi.cpp:1352 Registered camera /base/soc/i2c0mux/i2c@1/imx477@1a to Unicam device /dev/media2 and ISP device /dev/media0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from picamera2.picamera2 import *\n",
+    "picam2 = Picamera2()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Method #1: Using the set_controls function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "my_controls = {'NoiseReductionMode': 2,\n",
+    "               'Contrast': 1,\n",
+    "               'Sharpness': 1}\n",
+    "\n",
+    "picam2.set_controls(my_controls)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "The `Controls` class is automatically brought into the `Picamera2` class, so for most applications you probably won't need to\n",
+    "call it individually. It is renamed to `controls` when using it through the `Picamera2`.\n",
+    "To check the controls, you can use `controls.config`. The nice thing about this is that the function automatically compiles the controls you adjusted into a dictionary and checks their validity (within reason)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Contrast': 1, 'Sharpness': 1, 'NoiseReductionMode': 2}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picam2.controls.config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Method #2: Using class attributes.\n",
+    "Controls are imported from the `Controls` class, which treats each control as an attribute or property of the class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Contrast': 0, 'Sharpness': 0, 'NoiseReductionMode': 1}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picam2.controls.NoiseReductionMode = 1\n",
+    "picam2.controls.Contrast = 0\n",
+    "picam2.controls.Sharpness = 0\n",
+    "\n",
+    "picam2.controls.config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Control Input Options\n",
+    "\n",
+    "In most cases, `the Controls` class will notify you if the control you input is the incorrect value or type when\n",
+    "the camera reads in the controls. There are several ways you can input values for each control, but it depends on the control.\n",
+    "\n",
+    "To determine what the input types are for each control, you can use the annotation attribute of the `Controls` class. If you see something like (int,str) that means you can supply the control input as an integer OR string.\n",
+    "\n",
+    "As of writing this notebook, control names and enums must match the syntax of what libcamera uses.\n",
+    "For example, if you input \"off\", an error will be thrown by libcamera. The correct input would be \"Off\".\n",
+    "Another example would `picam2.controls.noisereductionmode` which would not register as a control option. The correct input would be `picam2.controls.NoiseReductionMode`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'AeEnable': (int, bool),\n",
+       " 'AeMeteringMode': (int, str),\n",
+       " 'AeConstraintMode': (int, str),\n",
+       " 'AeExposureMode': (int, str),\n",
+       " 'ExposureValue': (float, int),\n",
+       " 'ExposureTime': (float, int),\n",
+       " 'AnalogueGain': (float, int),\n",
+       " 'Brightness': (float, int),\n",
+       " 'Contrast': (float, int),\n",
+       " 'AwbEnable': (int, bool),\n",
+       " 'AwbMode': (int, str),\n",
+       " 'ColourGains': (tuple, list),\n",
+       " 'Saturation': (float, int),\n",
+       " 'Sharpness': (float, int),\n",
+       " 'ColourCorrectionMatrix': (tuple, list),\n",
+       " 'ScalerCrop': (tuple, list),\n",
+       " 'DigitalGain': (float, int),\n",
+       " 'FrameDurationLimits': (tuple, list),\n",
+       " 'AePrecaptureTrigger': int,\n",
+       " 'AfTrigger': int,\n",
+       " 'NoiseReductionMode': (int, str),\n",
+       " 'ColorCorrectionAberrationMode': (int, str),\n",
+       " 'SceneFlicker': (int, str),\n",
+       " 'PipelineDepth': int,\n",
+       " 'MaxLatency': int,\n",
+       " 'TestPatternMode': (int, str)}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picam2.controls.anno"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "For controls that configure camera modes, you can supply an integer, an enum, or string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#These all turn off NoiseReductionMode.\n",
+    "picam2.controls.NoiseReductionMode = 0\n",
+    "picam2.controls.NoiseReductionMode = libcamera.NoiseReductionMode.Off\n",
+    "picam2.controls.NoiseReductionMode = 'Off'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "For controls that enable or disable a function, you can supply an integer or bool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#These lines disable auto exposure mode.\n",
+    "\n",
+    "picam2.controls.AeEnable = 0\n",
+    "picam2.controls.AeEnable = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "For controls that require an array as input, you can supply it as a tuple or a list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#These both set the FrameDurationLimits to 33333 or 30 frames per second.\n",
+    "\n",
+    "picam2.controls.FrameDurationLimits = (33333,33333)\n",
+    "picam2.controls.FrameDurationLimits = [33333,33333]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Configuring the Controls\n",
+    "At this stage, we actually haven't sent the controls to the camera. The neat thing is that we don't\n",
+    "need to do this. This is done automatically when you tell the camera to start."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[0:18:19.167344748] [1775]  INFO Camera camera.cpp:1029 configuring streams: (0) 640x480-XBGR8888\n",
+      "[0:18:19.167802369] [1789]  INFO RPI raspberrypi.cpp:760 Sensor: /base/soc/i2c0mux/i2c@1/imx477@1a - Selected sensor format: 2028x1520-SBGGR12_1X12 - Selected unicam format: 2028x1520-pBCC\n",
+      "[0:18:20.939766348] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: NoiseReductionMode = 2\n",
+      "qt.qpa.xcb: QXcbConnection: XCB error: 148 (Unknown), sequence: 192, resource id: 0, major code: 140 (Unknown), minor code: 20\n"
+     ]
+    }
+   ],
+   "source": [
+    "picam2.controls.clear #You may not need this. It only clears the controls BEFORE the camera is started.\n",
+    "picam2.controls.NoiseReductionMode = 1\n",
+    "\n",
+    "picam2.configure(picam2.preview_configuration())\n",
+    "picam2.start_preview(Preview.QTGL)\n",
+    "picam2.start()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Control Manipulation\n",
+    "\n",
+    "All of the controls are technically class variables. That means that all instances of the class share the same values.\n",
+    "So controls can be updated by either method after the camera has already started, without having to start the camera again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[0:18:22.053895820] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: NoiseReductionMode = 2\n",
+      "[0:18:22.053950115] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.050000\n",
+      "[0:18:22.723722336] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.100000\n",
+      "[0:18:24.012997749] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.150000\n",
+      "[0:18:25.005245387] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.200000\n",
+      "[0:18:26.004152116] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.250000\n",
+      "[0:18:27.003592425] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.300000\n",
+      "[0:18:28.005935804] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.350000\n",
+      "[0:18:29.005101668] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.400000\n",
+      "[0:18:30.005799037] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.450000\n",
+      "[0:18:31.006512346] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.500000\n",
+      "[0:18:32.004173359] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.550000\n",
+      "[0:18:33.004429837] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.600000\n",
+      "[0:18:34.003704552] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.650000\n",
+      "[0:18:35.004224111] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.700000\n",
+      "[0:18:36.004944291] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.750000\n",
+      "[0:18:37.005849057] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.800000\n",
+      "[0:18:38.004842984] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.850000\n",
+      "[0:18:39.004907479] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.900000\n",
+      "[0:18:40.004485776] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 0.950000\n",
+      "[0:18:41.004951255] [1798]  INFO IPARPI raspberrypi.cpp:635 Request ctrl: Brightness = 1.000000\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for i in range(0,20):\n",
+    "    j = i/20 + 0.05\n",
+    "    picam2.controls.Brightness = j\n",
+    "    time.sleep(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Then to check the current controls we can use the `current` function."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "picam2.controls.current"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Current Settings\n",
+    "\n",
+    "After the settings that you assign are passed to the camera, the Controls()\n",
+    "class is effectively reset so that there is no risk of repetition. However,\n",
+    "the Controls() class does keep track of the current settings of the camera.\n",
+    "The current settings are always the settings that you last sent to the camera and that were accepted.\n",
+    "\n",
+    "If we look at the current settings now, we should see that the NoiseReductionMode is set to 2\n",
+    "and the Brightness is 1."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Resetting Controls (in development)\n",
+    "\n",
+    "If you wanted to reset the controls to what they were when you first turned on the camera,\n",
+    "you can issue the `reset` command. But first, we need to find out what the default controls were. If you compare it to the `ranges` function in the following cell, you may notice that some values are 0 when the 0 is technically outside the limits. This just means that the camera is handling these internally or in an automatic mode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'FrameDurationLimits': [0, 0],\n",
+       " 'ColourCorrectionMatrix': [0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+       " 'NoiseReductionMode': 0,\n",
+       " 'Contrast': 1.0,\n",
+       " 'AwbMode': 0,\n",
+       " 'ScalerCrop': (0, 0, 0, 0),\n",
+       " 'AwbEnable': 0,\n",
+       " 'ExposureValue': 0.0,\n",
+       " 'ColourGains': [0, 0],\n",
+       " 'AeExposureMode': 0,\n",
+       " 'Sharpness': 1.0,\n",
+       " 'Brightness': 0.0,\n",
+       " 'AeConstraintMode': 0,\n",
+       " 'AeMeteringMode': 0,\n",
+       " 'AnalogueGain': 0,\n",
+       " 'Saturation': 1.0,\n",
+       " 'ExposureTime': 0,\n",
+       " 'AeEnable': 0}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picam2.controls.defaults #This is a read-only property and will reflect whatever comes out of Picamera2().camera.controls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'AeEnable': 0,\n",
+       " 'AeMeteringMode': 0,\n",
+       " 'AeConstraintMode': 0,\n",
+       " 'AeExposureMode': 0,\n",
+       " 'ExposureValue': 0.0,\n",
+       " 'ExposureTime': 0,\n",
+       " 'AnalogueGain': 0,\n",
+       " 'Brightness': 0.0,\n",
+       " 'Contrast': 1.0,\n",
+       " 'AwbEnable': 0,\n",
+       " 'AwbMode': 0,\n",
+       " 'ColourGains': [0, 0],\n",
+       " 'Saturation': 1.0,\n",
+       " 'Sharpness': 1.0,\n",
+       " 'ColourCorrectionMatrix': [0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+       " 'ScalerCrop': (0, 0, 0, 0),\n",
+       " 'FrameDurationLimits': [0, 0],\n",
+       " 'NoiseReductionMode': 0}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picam2.controls.reset #Read only. Accepts no inputs.\n",
+    "picam2.controls.config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "We can see that the changes in the output reflect the values in the defaults."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## Control Ranges (in development)\n",
+    "To get an idea of the valid ranges for each control, you can use the ranges function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'FrameDurationLimits': {'min': 1000, 'max': 1000000000},\n",
+       " 'ColourCorrectionMatrix': {'min': -16.0, 'max': 16.0},\n",
+       " 'NoiseReductionMode': {'min': 0, 'max': 4},\n",
+       " 'Contrast': {'min': 0.0, 'max': 32.0},\n",
+       " 'AwbMode': {'min': 0, 'max': 7},\n",
+       " 'ScalerCrop': {'min': (0, 0, 0, 0), 'max': (65535, 65535, 65535, 65535)},\n",
+       " 'AwbEnable': {'min': False, 'max': True},\n",
+       " 'ExposureValue': {'min': -8.0, 'max': 8.0},\n",
+       " 'ColourGains': {'min': 0.0, 'max': 32.0},\n",
+       " 'AeExposureMode': {'min': 0, 'max': 3},\n",
+       " 'Sharpness': {'min': 0.0, 'max': 16.0},\n",
+       " 'Brightness': {'min': -1.0, 'max': 1.0},\n",
+       " 'AeConstraintMode': {'min': 0, 'max': 3},\n",
+       " 'AeMeteringMode': {'min': 0, 'max': 3},\n",
+       " 'AnalogueGain': {'min': 1.0, 'max': 32.0},\n",
+       " 'Saturation': {'min': 0.0, 'max': 32.0},\n",
+       " 'ExposureTime': {'min': 0, 'max': 999999},\n",
+       " 'AeEnable': {'min': False, 'max': True}}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picam2.controls.ranges #Read only."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## End of Example"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "outputs": [],
+   "source": [
+    "picam2.stop_preview()\n",
+    "picam2.stop()\n",
+    "picam2.close()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/opencv_mertens_merge.py
+++ b/examples/opencv_mertens_merge.py
@@ -22,17 +22,22 @@ picam2.stop()
 
 capture_config = picam2.preview_configuration(main={"size": (1024, 768), "format": "RGB888"})
 picam2.configure(capture_config)
-picam2.start({"ExposureTime": exposure_normal, "AnalogueGain": gain})
+picam2.controls.ExposureTime = exposure_normal
+picam2.controls.AnalogueGain = gain
+picam2.start()
 normal = picam2.capture_array()
 picam2.stop()
 
 exposure_short = int(exposure_normal / RATIO)
-picam2.start({"ExposureTime": exposure_short, "AnalogueGain": gain})
+picam2.set_controls({"ExposureTime": exposure_short, "AnalogueGain": gain})
+picam2.start()
 short = picam2.capture_array()
 picam2.stop()
 
 exposure_long = int(exposure_normal * RATIO)
-picam2.start({"ExposureTime": exposure_long, "AnalogueGain": gain})
+picam2.controls.ExposureTime = exposure_long
+picam2.controls.AnalogueGain = gain
+picam2.start()
 long = picam2.capture_array()
 picam2.stop()
 

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -8,8 +8,7 @@ class Controls():
     # This doesn't break anything and the NoneTypes aren't viewable to the
     # user. I suppose NoneType could be added to the types tuple, but that may
     # lead to confusion for the end user by implying that setting a control to
-    # None resets it to the original functionality.
-    # Sorry for any confusion future devs.
+    # None resets it to the original functionality, which is not the case.
 
     AeEnable: (int,bool) = None
     AeMeteringMode: (int,str) = None
@@ -122,26 +121,26 @@ class Controls():
     @property
     def ranges(self) -> dict:
         _ranges = {}
-        for ctrl,val in self._camera_controls.items():
-            _ranges[ctrl] = {'min': val[0],'max':val[1]}
+        for ctrl,val_tuple in self._camera_controls.items():
+            _ranges[ctrl] = {'min': val_tuple[0],'max':val_tuple[1]}
         return _ranges
 
     @property
     def defaults(self) -> dict:
         defaults = {}
-        for k,v in self._camera_controls.items():
-            if k == 'FrameDurationLimits':
-                if not isinstance(k,(list,tuple)):
-                    default_v = [v[-1]] * 2
-            elif k == 'ColourCorrectionMatrix':
-                if not isinstance (k,(list,tuple)):
-                    default_v = [v[-1]] * 9
-            elif k == 'ColourGains':
-                if not isinstance(k,(list,tuple)):
-                    default_v = [v[-1]] * 2
+        for ctrl,val_tuple in self._camera_controls.items():
+            if ctrl == 'FrameDurationLimits':
+                if not isinstance(ctrl,self.__annotations__[ctrl]):
+                    default_v = [val_tuple[-1]] * 2
+            elif ctrl == 'ColourCorrectionMatrix':
+                if not isinstance (ctrl,self.__annotations__[ctrl]):
+                    default_v = [val_tuple[-1]] * 9
+            elif ctrl == 'ColourGains':
+                if not isinstance(ctrl,self.__annotations__[ctrl]):
+                    default_v = [val_tuple[-1]] * 2
             else:
-                default_v = v[-1]
-            defaults[k] = default_v
+                default_v = val_tuple[-1]
+            defaults[ctrl] = default_v
         return defaults
 
     @property

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -10,34 +10,34 @@ class Controls():
     # lead to confusion for the end user by implying that setting a control to
     # None resets it to the original functionality, which is not the case.
 
-    AeEnable: (int,bool) = None
-    AeMeteringMode: (int,str) = None
-    AeConstraintMode: (int,str) = None
-    AeExposureMode: (int,str) = None
-    ExposureValue: (float,int) = None
-    ExposureTime: (float,int) = None
-    AnalogueGain: (float,int) = None
-    Brightness: (float,int) = None
-    Contrast: (float,int) = None
-    AwbEnable: (int,bool) = None
-    AwbMode: (int,str) = None
-    ColourGains: (tuple,list) = None
-    Saturation: (float,int) = None
-    Sharpness: (float,int) = None
-    ColourCorrectionMatrix: (tuple,list) = None
-    ScalerCrop: (tuple,list) = None
-    DigitalGain: (float,int) = None
-    FrameDurationLimits: (tuple,list) = None
+    AeEnable: (int, bool) = None
+    AeMeteringMode: (int, str) = None
+    AeConstraintMode: (int, str) = None
+    AeExposureMode: (int, str) = None
+    ExposureValue: (float, int) = None
+    ExposureTime: (float, int) = None
+    AnalogueGain: (float, int) = None
+    Brightness: (float, int) = None
+    Contrast: (float, int) = None
+    AwbEnable: (int, bool) = None
+    AwbMode: (int, str) = None
+    ColourGains: (tuple, list) = None
+    Saturation: (float, int) = None
+    Sharpness: (float, int) = None
+    ColourCorrectionMatrix: (tuple, list) = None
+    ScalerCrop: (tuple, list) = None
+    DigitalGain: (float, int) = None
+    FrameDurationLimits: (tuple, list) = None
     AePrecaptureTrigger: int = None
     AfTrigger: int = None
-    NoiseReductionMode: (int,str) = None
-    ColorCorrectionAberrationMode: (int,str) = None
-    SceneFlicker: (int,str) = None
+    NoiseReductionMode: (int, str) = None
+    ColorCorrectionAberrationMode: (int, str) = None
+    SceneFlicker: (int, str) = None
     PipelineDepth: int = None
     MaxLatency: int = None
-    TestPatternMode: (int,str) = None
+    TestPatternMode: (int, str) = None
 
-    def __init__(self,controls_from_libcamera):
+    def __init__(self, controls_from_libcamera):
         self._camera_controls = dict(sorted(controls_from_libcamera.items()))
         self._current = {}
         self._fps = None
@@ -70,15 +70,15 @@ class Controls():
         """
         controls = {}
         for attr, types in self.__annotations__.items():
-            val = getattr(self,attr)
-            if (not isinstance(val,types) #If not one of the defined types...
+            val = getattr(self, attr)
+            if (not isinstance(val, types)  # If not one of the defined types...
                     and val is not None  # or not defined as None...
-                    and attr not in str(val)):  #or not a libcamera type...
+                    and attr not in str(val)):  # or not a libcamera type...
                 raise TypeError(f"{attr} must be of these type(s): {types}")
-            if isinstance(val,str): #Assume val is mode if a string.
-                val = getattr(getattr(libcamera,attr),val)
+            if isinstance(val, str):  # Assume val is mode if a string.
+                val = getattr(getattr(libcamera, attr), val)
             controls[attr] = val
-        user_defined = {k:v for k,v in controls.items() if v is not None}
+        user_defined = {k: v for k, v in controls.items() if v is not None}
         user_defined = dict(sorted(user_defined.items()))
         return user_defined
 
@@ -98,14 +98,14 @@ class Controls():
         Its only use is to clear the controls at camera close.
         """
         for attr in self.__annotations__.keys():
-            setattr(self,attr,None)
+            setattr(self, attr, None)
 
     @property
     def fps(self):
         return self._fps
 
     @fps.setter
-    def fps(self,value) -> int:
+    def fps(self, value) -> int:
         """
         Converts a frames per seconds value to a microseconds value that
         the camera accepts.
@@ -115,135 +115,135 @@ class Controls():
             A tuple of values indicated a microseconds value that enables
             a fixed number of frames per second.
         """
-        uS = int(1e6/value)
-        self.FrameDurationLimits=(uS,uS)
+        uS = int(1e6 / value)
+        self.FrameDurationLimits = (uS, uS)
 
     @property
     def ranges(self) -> dict:
         _ranges = {}
-        for ctrl,val_tuple in self._camera_controls.items():
-            _ranges[ctrl] = {'min': val_tuple[0],'max':val_tuple[1]}
+        for ctrl, val_tuple in self._camera_controls.items():
+            _ranges[ctrl] = {'min': val_tuple[0], 'max': val_tuple[1]}
         _ranges = dict(sorted(_ranges.items()))
         return _ranges
 
     @property
     def defaults(self) -> dict:
         defaults = {}
-        for ctrl,val_tuple in self._camera_controls.items():
+        for ctrl, val_tuple in self._camera_controls.items():
             if ctrl == 'FrameDurationLimits':
-                if not isinstance(ctrl,self.__annotations__[ctrl]):
+                if not isinstance(ctrl, self.__annotations__[ctrl]):
                     default_v = [val_tuple[-1]] * 2
             elif ctrl == 'ColourCorrectionMatrix':
-                if not isinstance (ctrl,self.__annotations__[ctrl]):
+                if not isinstance(ctrl, self.__annotations__[ctrl]):
                     default_v = [val_tuple[-1]] * 9
             elif ctrl == 'ColourGains':
-                if not isinstance(ctrl,self.__annotations__[ctrl]):
+                if not isinstance(ctrl, self.__annotations__[ctrl]):
                     default_v = [val_tuple[-1]] * 2
             else:
                 default_v = val_tuple[-1]
             defaults[ctrl] = default_v
-        defaults = dict(sorted(defaults.items())) #Sort it alphabetically.
+        defaults = dict(sorted(defaults.items()))  # Sort it alphabetically.
         return defaults
 
     @property
     def reset(self):
-        for k,v in self.defaults.items():
-            setattr(self,k,v)
+        for k, v in self.defaults.items():
+            setattr(self, k, v)
 
     #
     # @property
     # def doc(self):
     #     print(self.__doc__)
 
-   #
-   # """
-   #  AeEnable:
-   #      Set the enable or disable state of the auto exposure.
-   #      Associated with ExposureTime and AnalogueGain.
-   #      0 = disable
-   #      1 = enable
-   #  AeMeteringMode:
-   #      Set the auto exposure metering mode. Modes determine which parts of the
-   #      image dictate scene brightness. Some metering modes may be platform
-   #      specific.
-   #  AeConstraintMode:
-   #      Set the auto exposure constraint mode. Modes determine how scene
-   #      brightness is adjusted to reach the desired targe exposure. Some
-   #      constraint modes may be platform specific.
-   #  AeExposureMode:
-   #      Set the auto exposure-exposure mode. Setting this mode specifies how the
-   #      total exposure is divided between the shutter time and the analogue
-   #      gain. Exposure mode may be platform specific.
-   #  ExposureValue:
-   #      Only applies when auto exposure is enabled.
-   #      This parameter adjust the exposure as a function of log2.
-   #      Associated with AeEnable.
-   #  ExposureTime:
-   #      Also considered the shutter speed for a frame. Value is specified
-   #      in micro-seconds. Associated with AnalogueGain and AeEnable.
-   #  AnalogueRain:
-   #      Specifies the gain multiplier of all colour channels. Cannot be less
-   #      than 1.0,with the exception of 0, which passes control back to auto
-   #      exposure. Associated with ExposureTime and AeEnable.
-   #  Brightness:
-   #      Sets the brightness to a fixed value. Value can be between -1.0 (darker)
-   #      and 1.0 (brighter). A value of 0 specifies no change.
-   #  Contrast:
-   #      Sets the contrast to a fixed value. Normal contrast has a value of 1.0.
-   #      Anything greater will increase the contrast.
-   #      Values smaller then 1.0 will decrease the contrast.
-   #  AwbEnable:
-   #      Enable or disable the auto white balance.
-   #      Associated with ColourGains.
-   #  AwbMode:
-   #      Set a mode that adjusts the range of illuminants. Modes may be platform
-   #      specific.
-   #  ColourGains:
-   #      Only works when AwbEnable is set to 0. Setting this value to a tuple or
-   #      list of values changes the
-   #      gain values for the red and blue channels, in that order.
-   #  Saturation:
-   #      Set a fixed saturation value. Normal is 1.0. Values greater than 1.0
-   #      enhance saturation.
-   #       A value of 0 produces a greyscale image.
-   #  Sharpness:
-   #      Adjust the sharpness of the image. 0 means no sharpness.
-   #      Sharpening cannot be less than 0 and does not apply to raw streams.
-   #  ColourCorrectionMatrix
-   #      Settings that convert the camera RGB to sRGB.
-   #  ScalerCrop
-   #      Assigns dimensionality the portion of the image that is to be scaled.
-   #  DigitalGain
-   #      Applies to all colour channels of a raw image.
-   #  FrameDurationLimits:
-   #      The minimum and maximum frame duration allowed (in microseconds).
-   #      Setting the minimum and maximum values to be the same creates a fixed
-   #      frame duration.
-   #      Example: [33333,33333]
-   #          This is equivalent to setting the frame duration to a fixed 33,333
-   #          microseconds. 1e6 uS/S * (1frame/33333uS) = 30 frames per second
-   #  AePrecaptureTrigger:
-   #      Controls the auto exposure metering trigger.
-   #  AfTrigger:
-   #      Controls when the auto focus is triggered.
-   #  NoiseReductionMode:
-   #      Select the noise reduction mode.
-   #      0 = No noise reduction is applied.
-   #      1 = Noise reduction applied with no impact to frame rate.
-   #      2 = High quality noise reduction, but with lost of frame rate.
-   #      3 = Minimal noise reduction with reduced impact to framerate.
-   #      4 = Noise reduction is applied at different levels to different streams.
-   #  ColorCorrectionAberrationMode:
-   #      Controls what mode is used for chromatic aberration correction.
-   #      0 = No correction.
-   #      1 = Some correction with no impact to frame rate.
-   #      2 = High quality correction with some potential impact to frame rate.
-   #  MaxLatency:
-   #      The number of frames that can occur after a request has been
-   #      submitted before synchronisity between the camera and newest
-   #      request is true.
-   #      -1 = Unknown latency
-   #      0 = Per-frame control
-   #  TestPatternMode
-   #      Select a test pattern control mode.
-   #  """
+#
+# """
+#  AeEnable:
+#      Set the enable or disable state of the auto exposure.
+#      Associated with ExposureTime and AnalogueGain.
+#      0 = disable
+#      1 = enable
+#  AeMeteringMode:
+#      Set the auto exposure metering mode. Modes determine which parts of the
+#      image dictate scene brightness. Some metering modes may be platform
+#      specific.
+#  AeConstraintMode:
+#      Set the auto exposure constraint mode. Modes determine how scene
+#      brightness is adjusted to reach the desired targe exposure. Some
+#      constraint modes may be platform specific.
+#  AeExposureMode:
+#      Set the auto exposure-exposure mode. Setting this mode specifies how the
+#      total exposure is divided between the shutter time and the analogue
+#      gain. Exposure mode may be platform specific.
+#  ExposureValue:
+#      Only applies when auto exposure is enabled.
+#      This parameter adjust the exposure as a function of log2.
+#      Associated with AeEnable.
+#  ExposureTime:
+#      Also considered the shutter speed for a frame. Value is specified
+#      in micro-seconds. Associated with AnalogueGain and AeEnable.
+#  AnalogueRain:
+#      Specifies the gain multiplier of all colour channels. Cannot be less
+#      than 1.0,with the exception of 0, which passes control back to auto
+#      exposure. Associated with ExposureTime and AeEnable.
+#  Brightness:
+#      Sets the brightness to a fixed value. Value can be between -1.0 (darker)
+#      and 1.0 (brighter). A value of 0 specifies no change.
+#  Contrast:
+#      Sets the contrast to a fixed value. Normal contrast has a value of 1.0.
+#      Anything greater will increase the contrast.
+#      Values smaller then 1.0 will decrease the contrast.
+#  AwbEnable:
+#      Enable or disable the auto white balance.
+#      Associated with ColourGains.
+#  AwbMode:
+#      Set a mode that adjusts the range of illuminants. Modes may be platform
+#      specific.
+#  ColourGains:
+#      Only works when AwbEnable is set to 0. Setting this value to a tuple or
+#      list of values changes the
+#      gain values for the red and blue channels, in that order.
+#  Saturation:
+#      Set a fixed saturation value. Normal is 1.0. Values greater than 1.0
+#      enhance saturation.
+#       A value of 0 produces a greyscale image.
+#  Sharpness:
+#      Adjust the sharpness of the image. 0 means no sharpness.
+#      Sharpening cannot be less than 0 and does not apply to raw streams.
+#  ColourCorrectionMatrix
+#      Settings that convert the camera RGB to sRGB.
+#  ScalerCrop
+#      Assigns dimensionality the portion of the image that is to be scaled.
+#  DigitalGain
+#      Applies to all colour channels of a raw image.
+#  FrameDurationLimits:
+#      The minimum and maximum frame duration allowed (in microseconds).
+#      Setting the minimum and maximum values to be the same creates a fixed
+#      frame duration.
+#      Example: [33333,33333]
+#          This is equivalent to setting the frame duration to a fixed 33,333
+#          microseconds. 1e6 uS/S * (1frame/33333uS) = 30 frames per second
+#  AePrecaptureTrigger:
+#      Controls the auto exposure metering trigger.
+#  AfTrigger:
+#      Controls when the auto focus is triggered.
+#  NoiseReductionMode:
+#      Select the noise reduction mode.
+#      0 = No noise reduction is applied.
+#      1 = Noise reduction applied with no impact to frame rate.
+#      2 = High quality noise reduction, but with lost of frame rate.
+#      3 = Minimal noise reduction with reduced impact to framerate.
+#      4 = Noise reduction is applied at different levels to different streams.
+#  ColorCorrectionAberrationMode:
+#      Controls what mode is used for chromatic aberration correction.
+#      0 = No correction.
+#      1 = Some correction with no impact to frame rate.
+#      2 = High quality correction with some potential impact to frame rate.
+#  MaxLatency:
+#      The number of frames that can occur after a request has been
+#      submitted before synchronisity between the camera and newest
+#      request is true.
+#      -1 = Unknown latency
+#      0 = Per-frame control
+#  TestPatternMode
+#      Select a test pattern control mode.
+#  """

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -37,10 +37,11 @@ class Controls():
     MaxLatency: int = None
     TestPatternMode: (int,str) = None
 
-    def __init__(self,camera_controls):
-        self._camera_controls = camera_controls
+    def __init__(self,controls_from_libcamera):
+        self._camera_controls = controls_from_libcamera
         self._current = {}
         self._fps = None
+        self.anno = self.__annotations__
 
     @property
     def config(self) -> dict:
@@ -92,10 +93,7 @@ class Controls():
     def clear(self):
         """
         This function resets all controls to None.
-        There doesn't really seem to be a use for this property yet and it could
-        be removed before picamera2 1.0.
-        Each attribute is reset to None after it is passed to the
-        camera_manager anyway.
+        Its only use is to clear the controls at camera close.
         """
         for attr in self.__annotations__.keys():
             setattr(self,attr,None)

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -38,7 +38,7 @@ class Controls():
     TestPatternMode: (int,str) = None
 
     def __init__(self,controls_from_libcamera):
-        self._camera_controls = controls_from_libcamera
+        self._camera_controls = dict(sorted(controls_from_libcamera.items()))
         self._current = {}
         self._fps = None
         self.anno = self.__annotations__
@@ -79,6 +79,7 @@ class Controls():
                 val = getattr(getattr(libcamera,attr),val)
             controls[attr] = val
         user_defined = {k:v for k,v in controls.items() if v is not None}
+        user_defined = dict(sorted(user_defined.items()))
         return user_defined
 
     @property
@@ -87,6 +88,7 @@ class Controls():
         This function returns the current user-defined settings of the camera.
         It is only updated through the CompletedRequests module.
         """
+        current = dict(sorted(self._current.items()))
         return self._current
 
     @property
@@ -121,6 +123,7 @@ class Controls():
         _ranges = {}
         for ctrl,val_tuple in self._camera_controls.items():
             _ranges[ctrl] = {'min': val_tuple[0],'max':val_tuple[1]}
+        _ranges = dict(sorted(_ranges.items()))
         return _ranges
 
     @property
@@ -139,6 +142,7 @@ class Controls():
             else:
                 default_v = val_tuple[-1]
             defaults[ctrl] = default_v
+        defaults = dict(sorted(defaults.items())) #Sort it alphabetically.
         return defaults
 
     @property

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -1,0 +1,248 @@
+import libcamera
+
+
+class Controls():
+    # It is probably bad form to specify a required type and then to set it as
+    # NoneType, but the config functions searches for None and excludes them
+    # when self.config is passed to the libcamera camera start function.
+    # This doesn't break anything and the NoneTypes aren't viewable to the
+    # user. I suppose NoneType could be added to the types tuple, but that may
+    # lead to confusion for the end user by implying that setting a control to
+    # None resets it to the original functionality.
+    # Sorry for any confusion future devs.
+
+    AeEnable: (int,bool) = None
+    AeMeteringMode: (int,str) = None
+    AeConstraintMode: (int,str) = None
+    AeExposureMode: (int,str) = None
+    ExposureValue: (float,int) = None
+    ExposureTime: (float,int) = None
+    AnalogueGain: (float,int) = None
+    Brightness: (float,int) = None
+    Contrast: (float,int) = None
+    AwbEnable: (int,bool) = None
+    AwbMode: (int,str) = None
+    ColourGains: (tuple,list) = None
+    Saturation: (float,int) = None
+    Sharpness: (float,int) = None
+    ColourCorrectionMatrix: (tuple,list) = None
+    ScalerCrop: (tuple,list) = None
+    DigitalGain: (float,int) = None
+    FrameDurationLimits: (tuple,list) = None
+    AePrecaptureTrigger: int = None
+    AfTrigger: int = None
+    NoiseReductionMode: (int,str) = None
+    ColorCorrectionAberrationMode: (int,str) = None
+    SceneFlicker: (int,str) = None
+    PipelineDepth: int = None
+    MaxLatency: int = None
+    TestPatternMode: (int,str) = None
+
+    def __init__(self,camera_controls):
+        self._camera_controls = camera_controls
+        self._current = {}
+        self._fps = None
+
+    @property
+    def config(self) -> dict:
+        """
+        Get the user-defined controls configuration.
+        This function is read-only. Any changes to the output of this
+        function must either be issued as a property change
+        (e.g. .Contrast = 1) or through the
+        Picamera2() set_controls command as a supplied dictionary.
+
+        This function will use the __annotations__ attribute to obtain the
+        class vars and their required types. It will also check to see if the
+        class var is a libcamera._libcamera."control" type by simply converting
+        the libcamera control value to a string and checking it against the
+        name of the class var. Finally, for controls that have names for modes,
+        the user can supply a string matching the exact syntax of the option.
+
+        Finally, the function assumes that any control that is assigned a None
+        doesn't need to be changed and excludes it from the return, ensuring
+        that it is not passed to the camera_manager.
+
+        @return
+            Returned is a dictionary of camera controls that the user wants to
+            change. If all controls are set to none, then the returned dict
+            is empty, which is still accepted by the camera_manager.
+        """
+        controls = {}
+        for attr, types in self.__annotations__.items():
+            val = getattr(self,attr)
+            if (not isinstance(val,types) #If not one of the defined types...
+                    and val is not None  # or not defined as None...
+                    and attr not in str(val)):  #or not a libcamera type...
+                raise TypeError(f"{attr} must be of these type(s): {types}")
+            if isinstance(val,str): #Assume val is mode if a string.
+                val = getattr(getattr(libcamera,attr),val)
+            controls[attr] = val
+        user_defined = {k:v for k,v in controls.items() if v is not None}
+        return user_defined
+
+    @property
+    def current(self):
+        """
+        This function returns the current user-defined settings of the camera.
+        It is only updated through the CompletedRequests module.
+        """
+        return self._current
+
+    @property
+    def clear(self):
+        """
+        This function resets all controls to None.
+        There doesn't really seem to be a use for this property yet and it could
+        be removed before picamera2 1.0.
+        Each attribute is reset to None after it is passed to the
+        camera_manager anyway.
+        """
+        for attr in self.__annotations__.keys():
+            setattr(self,attr,None)
+
+    @property
+    def fps(self):
+        return self._fps
+
+    @fps.setter
+    def fps(self,value) -> int:
+        """
+        Converts a frames per seconds value to a microseconds value that
+        the camera accepts.
+        @param value
+            A value with units of frames per second.
+        @return
+            A tuple of values indicated a microseconds value that enables
+            a fixed number of frames per second.
+        """
+        uS = int(1e6/value)
+        self.FrameDurationLimits=(uS,uS)
+
+    @property
+    def ranges(self) -> dict:
+        _ranges = {}
+        for ctrl,val in self._camera_controls.items():
+            _ranges[ctrl] = {'min': val[0],'max':val[1]}
+        return _ranges
+
+    @property
+    def defaults(self) -> dict:
+        defaults = {}
+        for k,v in self._camera_controls.items():
+            if k == 'FrameDurationLimits':
+                if not isinstance(k,(list,tuple)):
+                    default_v = [v[-1]] * 2
+            elif k == 'ColourCorrectionMatrix':
+                if not isinstance (k,(list,tuple)):
+                    default_v = [v[-1]] * 9
+            elif k == 'ColourGains':
+                if not isinstance(k,(list,tuple)):
+                    default_v = [v[-1]] * 2
+            else:
+                default_v = v[-1]
+            defaults[k] = default_v
+        return defaults
+
+    @property
+    def reset(self):
+        for k,v in self.defaults.items():
+            setattr(self,k,v)
+
+    #
+    # @property
+    # def doc(self):
+    #     print(self.__doc__)
+
+   #
+   # """
+   #  AeEnable:
+   #      Set the enable or disable state of the auto exposure.
+   #      Associated with ExposureTime and AnalogueGain.
+   #      0 = disable
+   #      1 = enable
+   #  AeMeteringMode:
+   #      Set the auto exposure metering mode. Modes determine which parts of the
+   #      image dictate scene brightness. Some metering modes may be platform
+   #      specific.
+   #  AeConstraintMode:
+   #      Set the auto exposure constraint mode. Modes determine how scene
+   #      brightness is adjusted to reach the desired targe exposure. Some
+   #      constraint modes may be platform specific.
+   #  AeExposureMode:
+   #      Set the auto exposure-exposure mode. Setting this mode specifies how the
+   #      total exposure is divided between the shutter time and the analogue
+   #      gain. Exposure mode may be platform specific.
+   #  ExposureValue:
+   #      Only applies when auto exposure is enabled.
+   #      This parameter adjust the exposure as a function of log2.
+   #      Associated with AeEnable.
+   #  ExposureTime:
+   #      Also considered the shutter speed for a frame. Value is specified
+   #      in micro-seconds. Associated with AnalogueGain and AeEnable.
+   #  AnalogueRain:
+   #      Specifies the gain multiplier of all colour channels. Cannot be less
+   #      than 1.0,with the exception of 0, which passes control back to auto
+   #      exposure. Associated with ExposureTime and AeEnable.
+   #  Brightness:
+   #      Sets the brightness to a fixed value. Value can be between -1.0 (darker)
+   #      and 1.0 (brighter). A value of 0 specifies no change.
+   #  Contrast:
+   #      Sets the contrast to a fixed value. Normal contrast has a value of 1.0.
+   #      Anything greater will increase the contrast.
+   #      Values smaller then 1.0 will decrease the contrast.
+   #  AwbEnable:
+   #      Enable or disable the auto white balance.
+   #      Associated with ColourGains.
+   #  AwbMode:
+   #      Set a mode that adjusts the range of illuminants. Modes may be platform
+   #      specific.
+   #  ColourGains:
+   #      Only works when AwbEnable is set to 0. Setting this value to a tuple or
+   #      list of values changes the
+   #      gain values for the red and blue channels, in that order.
+   #  Saturation:
+   #      Set a fixed saturation value. Normal is 1.0. Values greater than 1.0
+   #      enhance saturation.
+   #       A value of 0 produces a greyscale image.
+   #  Sharpness:
+   #      Adjust the sharpness of the image. 0 means no sharpness.
+   #      Sharpening cannot be less than 0 and does not apply to raw streams.
+   #  ColourCorrectionMatrix
+   #      Settings that convert the camera RGB to sRGB.
+   #  ScalerCrop
+   #      Assigns dimensionality the portion of the image that is to be scaled.
+   #  DigitalGain
+   #      Applies to all colour channels of a raw image.
+   #  FrameDurationLimits:
+   #      The minimum and maximum frame duration allowed (in microseconds).
+   #      Setting the minimum and maximum values to be the same creates a fixed
+   #      frame duration.
+   #      Example: [33333,33333]
+   #          This is equivalent to setting the frame duration to a fixed 33,333
+   #          microseconds. 1e6 uS/S * (1frame/33333uS) = 30 frames per second
+   #  AePrecaptureTrigger:
+   #      Controls the auto exposure metering trigger.
+   #  AfTrigger:
+   #      Controls when the auto focus is triggered.
+   #  NoiseReductionMode:
+   #      Select the noise reduction mode.
+   #      0 = No noise reduction is applied.
+   #      1 = Noise reduction applied with no impact to frame rate.
+   #      2 = High quality noise reduction, but with lost of frame rate.
+   #      3 = Minimal noise reduction with reduced impact to framerate.
+   #      4 = Noise reduction is applied at different levels to different streams.
+   #  ColorCorrectionAberrationMode:
+   #      Controls what mode is used for chromatic aberration correction.
+   #      0 = No correction.
+   #      1 = Some correction with no impact to frame rate.
+   #      2 = High quality correction with some potential impact to frame rate.
+   #  MaxLatency:
+   #      The number of frames that can occur after a request has been
+   #      submitted before synchronisity between the camera and newest
+   #      request is true.
+   #      -1 = Unknown latency
+   #      0 = Per-frame control
+   #  TestPatternMode
+   #      Select a test pattern control mode.
+   #  """

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -71,9 +71,9 @@ class Controls():
         controls = {}
         for attr, types in self.__annotations__.items():
             val = getattr(self, attr)
-            if (not isinstance(val, types)  # If not one of the defined types...
-                    and val is not None  # or not defined as None...
-                    and attr not in str(val)):  # or not a libcamera type...
+            if (not isinstance(val, types) and
+                    val is not None and
+                    attr not in str(val)):
                 raise TypeError(f"{attr} must be of these type(s): {types}")
             if isinstance(val, str):  # Assume val is mode if a string.
                 val = getattr(getattr(libcamera, attr), val)

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -685,7 +685,7 @@ class Picamera2:
     def switch_mode_(self, camera_config):
         self.stop_()
         self.configure_(camera_config)
-        self.start_()
+        self._start()
         self.async_result = self.camera_config
         return True
 

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1,24 +1,24 @@
 #!/usr/bin/python3
 
-import os
+from enum import Enum
+import json
 import libcamera
 import numpy as np
-import threading
+import os
+import piexif
 from PIL import Image
-from picamera2.encoders.encoder import Encoder
-from picamera2.encoders.output import *
-
-import time
 import tempfile
-import json
+import threading
+import time
+
+from picamera2.encoders.encoder import Encoder
+from picamera2.controls import *
+from picamera2.converters import *
 from picamera2.utils.picamera2_logger import *
 from picamera2.previews.null_preview import *
 from picamera2.previews.drm_preview import *
 from picamera2.previews.qt_preview import *
 from picamera2.previews.qt_gl_preview import *
-from enum import Enum
-import piexif
-
 
 STILL = libcamera.StreamRole.StillCapture
 RAW = libcamera.StreamRole.Raw

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1,24 +1,24 @@
 #!/usr/bin/python3
 
-from enum import Enum
-import json
+import os
 import libcamera
 import numpy as np
-import os
-import piexif
-from PIL import Image
-import tempfile
 import threading
-import time
-
+from PIL import Image
 from picamera2.encoders.encoder import Encoder
-from picamera2.controls import *
-from picamera2.converters import *
+from picamera2.encoders.output import *
+
+import time
+import tempfile
+import json
 from picamera2.utils.picamera2_logger import *
 from picamera2.previews.null_preview import *
 from picamera2.previews.drm_preview import *
 from picamera2.previews.qt_preview import *
 from picamera2.previews.qt_gl_preview import *
+from enum import Enum
+import piexif
+
 
 STILL = libcamera.StreamRole.StillCapture
 RAW = libcamera.StreamRole.Raw

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -77,6 +77,7 @@ class Picamera2:
         self._reset_flags()
         try:
             self.open_camera()
+            self._setup_controls()
             self.log.debug(f"{self.camera_manager}")
         except Exception:
             self.log.error("Camera __init__ sequence did not complete.")
@@ -119,8 +120,7 @@ class Picamera2:
         self.async_operation_in_progress = False
         self.async_result = None
         self.async_error = None
-        self.controls_lock = threading.Lock()
-        self.controls = {}
+
         self.options = {}
         self._encoder = None
         self.request_callback = None

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -959,9 +959,10 @@ class CompletedRequest:
                 if self.stop_count == self.picam2.stop_count:
                     self.request.reuse()
                     with self.picam2.controls_lock:
-                        for key, value in self.picam2.controls.items():
+                        for key, value in self.picam2.controls.config.items():
                             self.request.set_control(key, value)
-                            self.picam2.controls = {}
+                            self.picam2.controls._current[key] = value
+                            setattr(self.picam2.controls,key,None)
                         self.picam2.camera.queueRequest(self.request)
                 self.request = None
 

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -229,6 +229,7 @@ class Picamera2:
             self.libcamera_config = None
             self.streams = None
             self.stream_map = None
+            self.controls.clear
             self.log.info(f'Camera closed successfully.')
 
     def make_initial_stream_config(self, stream_config, updates):
@@ -249,7 +250,8 @@ class Picamera2:
         self.align_stream(main)
         lores = self.make_initial_stream_config({"format": "YUV420", "size": main["size"]}, lores)
         raw = self.make_initial_stream_config({"format": self.sensor_format, "size": main["size"]}, raw)
-        controls = {"NoiseReductionMode": 3} | controls
+        self.controls.NoiseReductionMode = 3
+        self.set_controls(controls)
         return {"use_case": "preview",
                 "transform": transform,
                 "colour_space": colour_space,
@@ -267,7 +269,8 @@ class Picamera2:
         self.align_stream(main)
         lores = self.make_initial_stream_config({"format": "YUV420", "size": main["size"]}, lores)
         raw = self.make_initial_stream_config({"format": self.sensor_format, "size": main["size"]}, raw)
-        controls = {"NoiseReductionMode": 2} | controls
+        self.controls.NoiseReductionMode = 2
+        self.set_controls(controls)
         return {"use_case": "still",
                 "transform": transform,
                 "colour_space": colour_space,
@@ -295,7 +298,9 @@ class Picamera2:
                 colour_space = libcamera.ColorSpace.Smpte170m()
             else:
                 colour_space = libcamera.ColorSpace.Rec709()
-        controls = {"NoiseReductionMode": 1, "FrameDurationLimits": (33333, 33333)} | controls
+        self.controls.NoiseReductionMode = 1
+        self.controls.fps = 30
+        self.set_controls(controls)
         return {"use_case": "video",
                 "transform": transform,
                 "colour_space": colour_space,

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -19,7 +19,6 @@ from picamera2.previews.qt_gl_preview import *
 from enum import Enum
 import piexif
 
-
 STILL = libcamera.StreamRole.StillCapture
 RAW = libcamera.StreamRole.Raw
 VIDEO = libcamera.StreamRole.VideoRecording
@@ -35,7 +34,6 @@ class Preview(Enum):
 
 
 class Picamera2:
-
     """Welcome to the PiCamera2 class."""
 
     @staticmethod
@@ -88,19 +86,19 @@ class Picamera2:
 
     def _setup_controls(self):
         self.controls_lock = threading.Lock()
-        self.controls = Controls(self.camera.controls) #Pass default controls.
+        self.controls = Controls(self.camera.controls)  # Pass default controls.
 
     def set_controls(self, controls: dict):
         with self.controls_lock:
-            for ctrl,val in controls.items():
+            for ctrl, val in controls.items():
                 if ctrl not in self.controls.__annotations__.keys():
-                    raise ValueError(f"{k} is not a valid camera control.")
+                    raise ValueError(f"{ctrl} is not a valid camera control.")
                 elif val is None:
                     msg = f"""{ctrl} cannot be NoneType. 
                     You can exclude it instead."""
                     raise ValueError(msg)
                 else:
-                    setattr(self.controls,ctrl,val)
+                    setattr(self.controls, ctrl, val)
 
     def _reset_flags(self):
         self.camera = None
@@ -242,7 +240,8 @@ class Picamera2:
             stream_config["size"] = updates["size"]
         return stream_config
 
-    def preview_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=4, controls={}):
+    def preview_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(),
+                              colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=4, controls={}):
         "Make a configuration suitable for camera preview."
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -261,7 +260,8 @@ class Picamera2:
                 "raw": raw,
                 "controls": controls}
 
-    def still_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=2, controls={}):
+    def still_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(),
+                            colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=2, controls={}):
         "Make a configuration suitable for still image capture. Default to 2 buffers, as the Gl preview would need them."
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -280,7 +280,8 @@ class Picamera2:
                 "raw": raw,
                 "controls": controls}
 
-    def video_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=None, buffer_count=6, controls={}):
+    def video_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=None,
+                            buffer_count=6, controls={}):
         "Make a configuration suitable for video recording."
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -391,7 +392,8 @@ class Picamera2:
         self.update_libcamera_stream_config(libcamera_config.at(self.main_index), camera_config["main"], buffer_count)
         libcamera_config.at(self.main_index).colorSpace = camera_config["colour_space"]
         if self.lores_index >= 0:
-            self.update_libcamera_stream_config(libcamera_config.at(self.lores_index), camera_config["lores"], buffer_count)
+            self.update_libcamera_stream_config(libcamera_config.at(self.lores_index), camera_config["lores"],
+                                                buffer_count)
             libcamera_config.at(self.lores_index).colorSpace = camera_config["colour_space"]
         if self.raw_index >= 0:
             self.update_libcamera_stream_config(libcamera_config.at(self.raw_index), camera_config["raw"], buffer_count)
@@ -523,7 +525,6 @@ class Picamera2:
         """Return the stream configuration for the named stream."""
         return self.camera_config[name]
 
-
     def _start(self):
         start_state = self.camera.start(self.controls.config)
         if start_state < 0:
@@ -534,7 +535,6 @@ class Picamera2:
                 self.camera.queueRequest(request)
             self.log.info("Camera started")
             self.started = True
-
 
     def start(self):
         """Start the camera system running."""
@@ -567,7 +567,6 @@ class Picamera2:
             self.wait()
         else:
             self.stop_()
-
 
     def get_completed_requests(self):
         # Return all the requests that libcamera has completed.
@@ -701,7 +700,8 @@ class Picamera2:
         if wait:
             return self.wait()
 
-    def switch_mode_and_capture_file(self, camera_config, filename, name="main", wait=True, signal_function=signal_event):
+    def switch_mode_and_capture_file(self, camera_config, filename, name="main", wait=True,
+                                     signal_function=signal_event):
         """Switch the camera into a new (capture) mode, capture an image to file, then return
         back to the initial camera mode."""
         preview_config = self.camera_config
@@ -967,7 +967,7 @@ class CompletedRequest:
                         for key, value in self.picam2.controls.config.items():
                             self.request.set_control(key, value)
                             self.picam2.controls._current[key] = value
-                            setattr(self.picam2.controls,key,None)
+                            setattr(self.picam2.controls, key, None)
                         self.picam2.camera.queueRequest(self.request)
                 self.request = None
 
@@ -1051,4 +1051,4 @@ class CompletedRequest:
         img.save(filename, compress_level=png_compress_level, quality=jpeg_quality, exif=exif)
         end_time = time.monotonic()
         self.picam2.log.info(f"Saved {self} to file {filename}.")
-        self.picam2.log.info(f"Time taken for encode: {(end_time-start_time)*1000} ms.")
+        self.picam2.log.info(f"Time taken for encode: {(end_time - start_time) * 1000} ms.")

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -117,7 +117,7 @@ class Picamera2:
         self.event = threading.Event()
         self.asynchronous = False
         self.async_operation_in_progress = False
-        self.asyc_result = None
+        self.async_result = None
         self.async_error = None
         self.controls_lock = threading.Lock()
         self.controls = {}

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -519,26 +519,26 @@ class Picamera2:
         return self.camera_config[name]
 
 
-    def start_(self, controls={}):
+    def _start(self):
+        start_state = self.camera.start(self.controls.config)
+        if start_state < 0:
+            self.log.error("Camera did not start properly.")
+            raise RuntimeError("Camera did not start properly.")
+        else:
+            for request in self.make_requests():
+                self.camera.queueRequest(request)
+            self.log.info("Camera started")
+            self.started = True
+
+
+    def start(self):
+        """Start the camera system running."""
         """Start the camera system running."""
         if self.camera_config is None:
             raise RuntimeError("Camera has not been configured")
         if self.started:
             raise RuntimeError("Camera already started")
-        if self.camera.start(self.camera_config["controls"] | controls) >= 0:
-            for request in self.make_requests():
-                self.camera.queueRequest(request)
-            self.log.info("Camera started")
-            self.started = True
-        else:
-            self.log.error("Camera did not start properly.")
-            raise RuntimeError("Camera did not start properly.")
-
-    def start(self, controls={}):
-        """Start the camera system running."""
-        if self.camera_config is None:
-            raise RuntimeError("Camera has not been configured")
-        self.start_(controls)
+        self._start()
 
     def stop_(self, request=None):
         """Stop the camera. Only call this function directly from within the camera event


### PR DESCRIPTION
This adds the controls module and Controls class.

This class handles controls in Picamera2(), providing several methods for issuing control changes to the camera.
Please see[ Jupyter Notebook](https://github.com/IanTBlack/picamera2/blob/controls/examples/notebooks/controls_example.ipynb).

There are also some commented lines in the controls module for documentation. Should those be taken out in favor of a ReadtheDocs?

It would also help to confirm the datatypes that libcamera requires for each control.
Reverted imports change to reduce conflict with PR #82 

Thanks!
Signed-off-by: Ian Black <blackia@oregonstate.edu>