### PR TITLE
Use Black for Formatting

### DIFF
--- a/.github/workflows/style-checker.yml
+++ b/.github/workflows/style-checker.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Check style
       run: |
         pip3 install black
-        black --check picamera2
+        black --check --diff picamera2

--- a/.github/workflows/style-checker.yml
+++ b/.github/workflows/style-checker.yml
@@ -5,8 +5,7 @@ on:
 
 jobs:
   style-check:
-
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -15,4 +14,6 @@ jobs:
         clean: true
 
     - name: Check style
-      run: ${{github.workspace}}/tools/checkstyle.py $(git log --format=%P -1 | awk '{print $1 ".." $2}')
+      run: |
+        pip3 install black
+        black --check picamera2

--- a/picamera2/converters.py
+++ b/picamera2/converters.py
@@ -1,9 +1,13 @@
 import numpy as np
 
 
-YUV2RGB_JPEG      = np.array([[1.0,   1.0,   1.0  ], [0.0, -0.344, 1.772], [1.402, -0.714, 0.0]])
-YUV2RGB_SMPTE170M = np.array([[1.164, 1.164, 1.164], [0.0, -0.392, 2.017], [1.596, -0.813, 0.0]])
-YUV2RGB_REC709    = np.array([[1.164, 1.164, 1.164], [0.0, -0.213, 2.112], [1.793, -0.533, 0.0]])
+YUV2RGB_JPEG = np.array([[1.0, 1.0, 1.0], [0.0, -0.344, 1.772], [1.402, -0.714, 0.0]])
+YUV2RGB_SMPTE170M = np.array(
+    [[1.164, 1.164, 1.164], [0.0, -0.392, 2.017], [1.596, -0.813, 0.0]]
+)
+YUV2RGB_REC709 = np.array(
+    [[1.164, 1.164, 1.164], [0.0, -0.213, 2.112], [1.793, -0.533, 0.0]]
+)
 
 
 def YUV420_to_RGB(YUV_in, size, matrix=YUV2RGB_JPEG, rb_swap=True, final_width=0):
@@ -19,8 +23,8 @@ def YUV420_to_RGB(YUV_in, size, matrix=YUV2RGB_JPEG, rb_swap=True, final_width=0
 
     YUV = np.empty((h2, w2, 3), dtype=int)
     YUV[:, :, 0] = YUV_in[:n].reshape(h, w)[0::2, 0::2]
-    YUV[:, :, 1] = YUV_in[n:n + n4].reshape(h2, w2) - 128.0
-    YUV[:, :, 2] = YUV_in[n + n4:n + n2].reshape(h2, w2) - 128.0
+    YUV[:, :, 1] = YUV_in[n : n + n4].reshape(h2, w2) - 128.0
+    YUV[:, :, 2] = YUV_in[n + n4 : n + n2].reshape(h2, w2) - 128.0
 
     if rb_swap:
         matrix = matrix[:, [2, 1, 0]]

--- a/picamera2/encoders/encoder.py
+++ b/picamera2/encoders/encoder.py
@@ -1,8 +1,8 @@
 from v4l2 import *
 from ..outputs import Output
 
-class Encoder:
 
+class Encoder:
     def __init__(self):
         self._width = 0
         self._height = 0

--- a/picamera2/encoders/jpeg_encoder.py
+++ b/picamera2/encoders/jpeg_encoder.py
@@ -4,11 +4,13 @@ from picamera2.encoders.multi_encoder import MultiEncoder
 
 
 class JpegEncoder(MultiEncoder):
-    def __init__(self, num_threads=4, q=85, colour_space='RGBX'):
+    def __init__(self, num_threads=4, q=85, colour_space="RGBX"):
         super().__init__(num_threads=num_threads)
         self.q = q
         self.colour_space = colour_space
 
     def encode_func(self, request, name):
         array = request.make_array(name)
-        return simplejpeg.encode_jpeg(array, quality=self.q, colorspace=self.colour_space)
+        return simplejpeg.encode_jpeg(
+            array, quality=self.q, colorspace=self.colour_space
+        )

--- a/picamera2/encoders/multi_encoder.py
+++ b/picamera2/encoders/multi_encoder.py
@@ -14,6 +14,7 @@ class MultiEncoder(Encoder):
     num_threads - the number of parallel threads to use. Probably match this to the
                   number of cores available for best performance.
     """
+
     def __init__(self, num_threads=4):
         super().__init__()
         self.threads = ThreadPoolExecutor(num_threads)

--- a/picamera2/encoders/v4l2_encoder.py
+++ b/picamera2/encoders/v4l2_encoder.py
@@ -19,12 +19,14 @@ class V4L2Encoder(Encoder):
 
     def _start(self):
         super()._start()
-        self.vd = open('/dev/video11', 'rb+', buffering=0)
+        self.vd = open("/dev/video11", "rb+", buffering=0)
 
         self.buf_available = queue.Queue()
         self.buf_frame = queue.Queue()
 
-        self.thread = threading.Thread(target=self.thread_poll, args=(self.buf_available,))
+        self.thread = threading.Thread(
+            target=self.thread_poll, args=(self.buf_available,)
+        )
         self.thread.setDaemon(True)
         self.thread.start()
 
@@ -101,8 +103,16 @@ class V4L2Encoder(Encoder):
             buffer.length = 1
             buffer.m.planes = planes
             ret = fcntl.ioctl(self.vd, VIDIOC_QUERYBUF, buffer)
-            self.bufs[i] = (mmap.mmap(self.vd.fileno(), buffer.m.planes[0].length, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED,
-                                      offset=buffer.m.planes[0].m.mem_offset), buffer.m.planes[0].length)
+            self.bufs[i] = (
+                mmap.mmap(
+                    self.vd.fileno(),
+                    buffer.m.planes[0].length,
+                    mmap.PROT_READ | mmap.PROT_WRITE,
+                    mmap.MAP_SHARED,
+                    offset=buffer.m.planes[0].m.mem_offset,
+                ),
+                buffer.m.planes[0].length,
+            )
             ret = fcntl.ioctl(self.vd, VIDIOC_QBUF, buffer)
 
         typev = v4l2_buf_type(V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE)
@@ -158,7 +168,9 @@ class V4L2Encoder(Encoder):
                     buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE
                     buf.memory = V4L2_MEMORY_MMAP
                     buf.length = 1
-                    ctypes.memset(planes, 0, ctypes.sizeof(v4l2_plane) * VIDEO_MAX_PLANES)
+                    ctypes.memset(
+                        planes, 0, ctypes.sizeof(v4l2_plane) * VIDEO_MAX_PLANES
+                    )
                     buf.m.planes = planes
                     ret = fcntl.ioctl(self.vd, VIDIOC_DQBUF, buf)
                     keyframe = (buf.flags & V4L2_BUF_FLAG_KEYFRAME) != 0

--- a/picamera2/previews/gl_helpers.py
+++ b/picamera2/previews/gl_helpers.py
@@ -1,11 +1,26 @@
-from OpenGL.EGL.VERSION.EGL_1_0 import EGLNativeDisplayType, eglGetProcAddress, eglQueryString, EGL_EXTENSIONS
+from OpenGL.EGL.VERSION.EGL_1_0 import (
+    EGLNativeDisplayType,
+    eglGetProcAddress,
+    eglQueryString,
+    EGL_EXTENSIONS,
+)
 
 from OpenGL.raw.GLES2 import _types as _cs
 from OpenGL.GLES2.VERSION.GLES2_2_0 import *
 from OpenGL.GLES3.VERSION.GLES3_3_0 import *
 from OpenGL import GL as gl
 
-from ctypes import c_int, c_char_p, c_void_p, cdll, POINTER, util, pointer, CFUNCTYPE, c_bool
+from ctypes import (
+    c_int,
+    c_char_p,
+    c_void_p,
+    cdll,
+    POINTER,
+    util,
+    pointer,
+    CFUNCTYPE,
+    c_bool,
+)
 
 
 def getEGLNativeDisplay():
@@ -28,7 +43,7 @@ glEGLImageTargetTexture2DOES = getglEGLImageTargetTexture2DOES()
 
 
 def str_to_fourcc(str):
-    assert(len(str) == 4)
+    assert len(str) == 4
     fourcc = 0
     for i, v in enumerate([ord(c) for c in str]):
         fourcc |= v << (i * 8)

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -7,7 +7,9 @@ class NullPreview:
         import selectors
 
         sel = selectors.DefaultSelector()
-        sel.register(picam2.camera_manager.efd, selectors.EVENT_READ, self.handle_request)
+        sel.register(
+            picam2.camera_manager.efd, selectors.EVENT_READ, self.handle_request
+        )
         self.event.set()
 
         while self.running:
@@ -15,7 +17,6 @@ class NullPreview:
             for key, mask in events:
                 callback = key.data
                 callback(picam2)
-
 
     def __init__(self, x=None, y=None, width=None, height=None):
         # Ignore width and height as they are meaningless. We only accept them so as to

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -6,6 +6,7 @@ from PyQt5.QtCore import Qt, pyqtSignal
 import sys
 import threading
 import os
+
 os.environ["PYOPENGL_PLATFORM"] = "egl"
 
 import OpenGL
@@ -50,12 +51,18 @@ class EglState:
         eglBindAPI(EGL_OPENGL_ES_API)
 
         config_attribs = [
-            EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
-            EGL_RED_SIZE, 8,
-            EGL_GREEN_SIZE, 8,
-            EGL_BLUE_SIZE, 8,
-            EGL_ALPHA_SIZE, 0,
-            EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+            EGL_SURFACE_TYPE,
+            EGL_WINDOW_BIT,
+            EGL_RED_SIZE,
+            8,
+            EGL_GREEN_SIZE,
+            8,
+            EGL_BLUE_SIZE,
+            8,
+            EGL_ALPHA_SIZE,
+            0,
+            EGL_RENDERABLE_TYPE,
+            EGL_OPENGL_ES2_BIT,
             EGL_NONE,
         ]
 
@@ -66,11 +73,14 @@ class EglState:
 
     def create_context(self):
         context_attribs = [
-            EGL_CONTEXT_CLIENT_VERSION, 2,
+            EGL_CONTEXT_CLIENT_VERSION,
+            2,
             EGL_NONE,
         ]
 
-        self.context = eglCreateContext(self.display, self.config, EGL_NO_CONTEXT, context_attribs)
+        self.context = eglCreateContext(
+            self.display, self.config, EGL_NO_CONTEXT, context_attribs
+        )
 
         eglMakeCurrent(self.display, EGL_NO_SURFACE, EGL_NO_SURFACE, self.context)
 
@@ -95,9 +105,12 @@ class QGlPicamera2(QWidget):
         self.stop_count = 0
         self.egl = EglState()
         if picam2.verbose_console:
-            print("EGL {} {}".format(
-                eglQueryString(self.egl.display, EGL_VENDOR).decode(),
-                eglQueryString(self.egl.display, EGL_VERSION).decode()))
+            print(
+                "EGL {} {}".format(
+                    eglQueryString(self.egl.display, EGL_VENDOR).decode(),
+                    eglQueryString(self.egl.display, EGL_VERSION).decode(),
+                )
+            )
         self.init_gl()
 
         # set_overlay could be called before the first frame arrives, hence:
@@ -105,9 +118,9 @@ class QGlPicamera2(QWidget):
 
         self.picamera2 = picam2
         picam2.have_event_loop = True
-        self.camera_notifier = QSocketNotifier(self.picamera2.camera_manager.efd,
-                                               QtCore.QSocketNotifier.Read,
-                                               self)
+        self.camera_notifier = QSocketNotifier(
+            self.picamera2.camera_manager.efd, QtCore.QSocketNotifier.Read, self
+        )
         self.camera_notifier.activated.connect(self.handle_requests)
 
     def cleanup(self):
@@ -127,8 +140,9 @@ class QGlPicamera2(QWidget):
 
     def create_surface(self):
         native_surface = c_void_p(self.winId().__int__())
-        surface = eglCreateWindowSurface(self.egl.display, self.egl.config,
-                                         native_surface, None)
+        surface = eglCreateWindowSurface(
+            self.egl.display, self.egl.config, native_surface, None
+        )
 
         self.surface = surface
 
@@ -176,19 +190,14 @@ class QGlPicamera2(QWidget):
 
         self.program_image = shaders.compileProgram(
             shaders.compileShader(vertShaderSrc, GL_VERTEX_SHADER),
-            shaders.compileShader(fragShaderSrc_image, GL_FRAGMENT_SHADER)
+            shaders.compileShader(fragShaderSrc_image, GL_FRAGMENT_SHADER),
         )
         self.program_overlay = shaders.compileProgram(
             shaders.compileShader(vertShaderSrc, GL_VERTEX_SHADER),
-            shaders.compileShader(fragShaderSrc_overlay, GL_FRAGMENT_SHADER)
+            shaders.compileShader(fragShaderSrc_overlay, GL_FRAGMENT_SHADER),
         )
 
-        vertPositions = [
-            0.0, 0.0,
-            1.0, 0.0,
-            1.0, 1.0,
-            0.0, 1.0
-        ]
+        vertPositions = [0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0]
 
         inputAttrib = glGetAttribLocation(self.program_image, "aPosition")
         glVertexAttribPointer(inputAttrib, 2, GL_FLOAT, GL_FALSE, 0, vertPositions)
@@ -222,7 +231,9 @@ class QGlPicamera2(QWidget):
             cfg = stream.configuration
             fmt = cfg.pixelFormat
             if fmt not in self.FMT_MAP:
-                raise RuntimeError(f"Format {fmt} not supported by QGlPicamera2 preview")
+                raise RuntimeError(
+                    f"Format {fmt} not supported by QGlPicamera2 preview"
+                )
             fmt = str_to_fourcc(self.FMT_MAP[fmt])
             w, h = cfg.size
 
@@ -230,43 +241,63 @@ class QGlPicamera2(QWidget):
                 h2 = h // 2
                 stride2 = cfg.stride // 2
                 attribs = [
-                    EGL_WIDTH, w,
-                    EGL_HEIGHT, h,
-                    EGL_LINUX_DRM_FOURCC_EXT, fmt,
-                    EGL_DMA_BUF_PLANE0_FD_EXT, fb.fd(0),
-                    EGL_DMA_BUF_PLANE0_OFFSET_EXT, 0,
-                    EGL_DMA_BUF_PLANE0_PITCH_EXT, cfg.stride,
-                    EGL_DMA_BUF_PLANE1_FD_EXT, fb.fd(0),
-                    EGL_DMA_BUF_PLANE1_OFFSET_EXT, h * cfg.stride,
-                    EGL_DMA_BUF_PLANE1_PITCH_EXT, stride2,
-                    EGL_DMA_BUF_PLANE2_FD_EXT, fb.fd(0),
-                    EGL_DMA_BUF_PLANE2_OFFSET_EXT, h * cfg.stride + h2 * stride2,
-                    EGL_DMA_BUF_PLANE2_PITCH_EXT, stride2,
+                    EGL_WIDTH,
+                    w,
+                    EGL_HEIGHT,
+                    h,
+                    EGL_LINUX_DRM_FOURCC_EXT,
+                    fmt,
+                    EGL_DMA_BUF_PLANE0_FD_EXT,
+                    fb.fd(0),
+                    EGL_DMA_BUF_PLANE0_OFFSET_EXT,
+                    0,
+                    EGL_DMA_BUF_PLANE0_PITCH_EXT,
+                    cfg.stride,
+                    EGL_DMA_BUF_PLANE1_FD_EXT,
+                    fb.fd(0),
+                    EGL_DMA_BUF_PLANE1_OFFSET_EXT,
+                    h * cfg.stride,
+                    EGL_DMA_BUF_PLANE1_PITCH_EXT,
+                    stride2,
+                    EGL_DMA_BUF_PLANE2_FD_EXT,
+                    fb.fd(0),
+                    EGL_DMA_BUF_PLANE2_OFFSET_EXT,
+                    h * cfg.stride + h2 * stride2,
+                    EGL_DMA_BUF_PLANE2_PITCH_EXT,
+                    stride2,
                     EGL_NONE,
                 ]
             else:
                 attribs = [
-                    EGL_WIDTH, w,
-                    EGL_HEIGHT, h,
-                    EGL_LINUX_DRM_FOURCC_EXT, fmt,
-                    EGL_DMA_BUF_PLANE0_FD_EXT, fb.fd(0),
-                    EGL_DMA_BUF_PLANE0_OFFSET_EXT, 0,
-                    EGL_DMA_BUF_PLANE0_PITCH_EXT, cfg.stride,
+                    EGL_WIDTH,
+                    w,
+                    EGL_HEIGHT,
+                    h,
+                    EGL_LINUX_DRM_FOURCC_EXT,
+                    fmt,
+                    EGL_DMA_BUF_PLANE0_FD_EXT,
+                    fb.fd(0),
+                    EGL_DMA_BUF_PLANE0_OFFSET_EXT,
+                    0,
+                    EGL_DMA_BUF_PLANE0_PITCH_EXT,
+                    cfg.stride,
                     EGL_NONE,
                 ]
 
-            image = eglCreateImageKHR(display,
-                                      EGL_NO_CONTEXT,
-                                      EGL_LINUX_DMA_BUF_EXT,
-                                      None,
-                                      attribs)
+            image = eglCreateImageKHR(
+                display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, None, attribs
+            )
 
             self.texture = glGenTextures(1)
             glBindTexture(GL_TEXTURE_EXTERNAL_OES, self.texture)
             glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
             glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
-            glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
-            glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
+            glTexParameteri(
+                GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE
+            )
+            glTexParameteri(
+                GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE
+            )
             glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, image)
 
             eglDestroyImageKHR(display, image)
@@ -279,15 +310,29 @@ class QGlPicamera2(QWidget):
                 # All this swapping round of contexts is a bit icky, but I'd rather copy
                 # the overlay here so that the user doesn't have to worry about us still
                 # using it after this function returns.
-                eglMakeCurrent(self.egl.display, self.surface, self.surface, self.egl.context)
+                eglMakeCurrent(
+                    self.egl.display, self.surface, self.surface, self.egl.context
+                )
                 glBindTexture(GL_TEXTURE_2D, self.overlay_texture)
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
                 (height, width, channels) = overlay.shape
-                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, overlay)
-                eglMakeCurrent(self.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)
+                glTexImage2D(
+                    GL_TEXTURE_2D,
+                    0,
+                    GL_RGBA,
+                    width,
+                    height,
+                    0,
+                    GL_RGBA,
+                    GL_UNSIGNED_BYTE,
+                    overlay,
+                )
+                eglMakeCurrent(
+                    self.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT
+                )
                 self.overlay_present = True
 
     def repaint(self, completed_request):
@@ -307,7 +352,9 @@ class QGlPicamera2(QWidget):
 
             if self.picamera2.verbose_console:
                 print("Make buffer for request", completed_request.request)
-            self.buffers[completed_request.request] = self.Buffer(self.egl.display, completed_request)
+            self.buffers[completed_request.request] = self.Buffer(
+                self.egl.display, completed_request
+            )
 
         buffer = self.buffers[completed_request.request]
 
@@ -335,7 +382,7 @@ class QGlPicamera2(QWidget):
                 self.repaint(request)
                 # The pipeline will stall if there's only one buffer and we always hold on to
                 # the last one. When we can, however, holding on to them is still preferred.
-                if self.picamera2.camera_config['buffer_count'] > 1:
+                if self.picamera2.camera_config["buffer_count"] > 1:
                     self.release_current = True
                 else:
                     request.release()

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -17,9 +17,9 @@ class QPicamera2(QWidget):
         self.label.resize(width, height)
         self.overlay = None
         self.painter = QtGui.QPainter()
-        self.camera_notifier = QSocketNotifier(self.picamera2.camera_manager.efd,
-                                               QtCore.QSocketNotifier.Read,
-                                               self)
+        self.camera_notifier = QSocketNotifier(
+            self.picamera2.camera_manager.efd, QtCore.QSocketNotifier.Read, self
+        )
         self.camera_notifier.activated.connect(self.handle_requests)
 
     def cleanup(self):
@@ -36,10 +36,16 @@ class QPicamera2(QWidget):
             overlay = np.ascontiguousarray(overlay)
             shape = overlay.shape
             size = self.label.size()
-            if orig is overlay and shape[1] == size.width() and shape[0] == size.height():
+            if (
+                orig is overlay
+                and shape[1] == size.width()
+                and shape[0] == size.height()
+            ):
                 # We must be sure to copy the data even when no one else does!
                 overlay = overlay.copy()
-            overlay = QtGui.QImage(overlay.data, shape[1], shape[0], QtGui.QImage.Format_RGBA8888)
+            overlay = QtGui.QImage(
+                overlay.data, shape[1], shape[0], QtGui.QImage.Format_RGBA8888
+            )
             if overlay.size() != self.label.size():
                 overlay = overlay.scaled(self.label.size())
 
@@ -54,7 +60,9 @@ class QPicamera2(QWidget):
         if self.picamera2.display_stream_name is not None:
             # This all seems horribly expensive. Pull request welcome if you know a better way!
             size = self.label.size()
-            img = request.make_image(self.picamera2.display_stream_name, size.width(), size.height())
+            img = request.make_image(
+                self.picamera2.display_stream_name, size.width(), size.height()
+            )
             qim = ImageQt(img)
             self.painter.begin(qim)
             overlay = self.overlay

--- a/picamera2/previews/qt_previews.py
+++ b/picamera2/previews/qt_previews.py
@@ -20,7 +20,9 @@ class QtPreviewBase:
 
         self.app = QApplication([])
         self.size = (self.width, self.height)
-        self.qpicamera2 = self.make_picamera2_widget(picam2, width=self.width, height=self.height)
+        self.qpicamera2 = self.make_picamera2_widget(
+            picam2, width=self.width, height=self.height
+        )
         if self.x is not None and self.y is not None:
             self.qpicamera2.move(self.x, self.y)
         self.qpicamera2.setWindowTitle(self.get_title())
@@ -46,7 +48,7 @@ class QtPreviewBase:
 
     def start(self, picam2):
         self.event = threading.Event()
-        self.thread = threading.Thread(target=self.thread_func, args=(picam2, ))
+        self.thread = threading.Thread(target=self.thread_func, args=(picam2,))
         self.thread.setDaemon(True)
         self.thread.start()
         self.event.wait()
@@ -63,6 +65,7 @@ class QtPreviewBase:
 class QtPreview(QtPreviewBase):
     def make_picamera2_widget(self, picam2, width=640, height=480):
         from picamera2.previews.q_picamera2 import QPicamera2
+
         return QPicamera2(picam2, width=self.width, height=self.height)
 
     def get_title(self):
@@ -72,6 +75,7 @@ class QtPreview(QtPreviewBase):
 class QtGlPreview(QtPreviewBase):
     def make_picamera2_widget(self, picam2, width=640, height=480):
         from picamera2.previews.q_gl_picamera2 import QGlPicamera2
+
         return QGlPicamera2(picam2, width=self.width, height=self.height)
 
     def get_title(self):

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -71,14 +71,14 @@ class CompletedRequest:
         if fmt in ("BGR888", "RGB888"):
             if stride != w * 3:
                 array = array.reshape((h, stride))
-                array = np.asarray(array[:, :w * 3], order='C')
+                array = np.asarray(array[:, : w * 3], order="C")
             image = array.reshape((h, w, 3))
         elif fmt in ("XBGR8888", "XRGB8888"):
             if stride != w * 4:
                 array = array.reshape((h, stride))
-                array = np.asarray(array[:, :w * 4], order='C')
+                array = np.asarray(array[:, : w * 4], order="C")
             image = array.reshape((h, w, 4))
-        elif fmt[0] == 'S':  # raw formats
+        elif fmt[0] == "S":  # raw formats
             image = array.reshape((h, stride))
         else:
             raise RuntimeError("Format " + fmt + " not supported")
@@ -88,9 +88,16 @@ class CompletedRequest:
         """Make a PIL image from the named stream's buffer."""
         rgb = self.make_array(name)
         fmt = self.picam2.camera_config[name]["format"]
-        mode_lookup = {"RGB888": "BGR", "BGR888": "RGB", "XBGR8888": "RGBA", "XRGB8888": "BGRX"}
+        mode_lookup = {
+            "RGB888": "BGR",
+            "BGR888": "RGB",
+            "XBGR8888": "RGBA",
+            "XRGB8888": "BGRX",
+        }
         mode = mode_lookup[fmt]
-        pil_img = Image.frombuffer("RGB", (rgb.shape[1], rgb.shape[0]), rgb, "raw", mode, 0, 1)
+        pil_img = Image.frombuffer(
+            "RGB", (rgb.shape[1], rgb.shape[0]), rgb, "raw", mode, 0, 1
+        )
         if width is None:
             width = rgb.shape[1]
         if height is None:
@@ -105,24 +112,30 @@ class CompletedRequest:
         # This is probably a hideously expensive way to do a capture.
         start_time = time.monotonic()
         img = self.make_image(name)
-        exif = b''
-        if filename.split('.')[-1].lower() in ('jpg', 'jpeg') and img.mode == "RGBA":
+        exif = b""
+        if filename.split(".")[-1].lower() in ("jpg", "jpeg") and img.mode == "RGBA":
             # Nasty hack. Qt doesn't understand RGBX so we have to use RGBA. But saving a JPEG
             # doesn't like RGBA to we have to bodge that to RGBX.
             img.mode = "RGBX"
             # Make up some extra EXIF data.
             metadata = self.get_metadata()
-            zero_ifd = {piexif.ImageIFD.Make: "Raspberry Pi",
-                        piexif.ImageIFD.Model: self.picam2.camera.id,
-                        piexif.ImageIFD.Software: "Picamera2"}
+            zero_ifd = {
+                piexif.ImageIFD.Make: "Raspberry Pi",
+                piexif.ImageIFD.Model: self.picam2.camera.id,
+                piexif.ImageIFD.Software: "Picamera2",
+            }
             total_gain = metadata["AnalogueGain"] * metadata["DigitalGain"]
-            exif_ifd = {piexif.ExifIFD.ExposureTime: (metadata["ExposureTime"], 1000000),
-                        piexif.ExifIFD.ISOSpeedRatings: int(total_gain * 100)}
+            exif_ifd = {
+                piexif.ExifIFD.ExposureTime: (metadata["ExposureTime"], 1000000),
+                piexif.ExifIFD.ISOSpeedRatings: int(total_gain * 100),
+            }
             exif = piexif.dump({"0th": zero_ifd, "Exif": exif_ifd})
         # compress_level=1 saves pngs much faster, and still gets most of the compression.
         png_compress_level = self.picam2.options.get("compress_level", 1)
         jpeg_quality = self.picam2.options.get("quality", 90)
-        img.save(filename, compress_level=png_compress_level, quality=jpeg_quality, exif=exif)
+        img.save(
+            filename, compress_level=png_compress_level, quality=jpeg_quality, exif=exif
+        )
         end_time = time.monotonic()
         self.picam2.log.info(f"Saved {self} to file {filename}.")
         self.picam2.log.info(f"Time taken for encode: {(end_time-start_time)*1000} ms.")

--- a/picamera2/utils/picamera2_logger.py
+++ b/picamera2/utils/picamera2_logger.py
@@ -11,7 +11,7 @@ Console Level Options
 
 
 def initialize_logger(console_level):
-    logger = logging.getLogger('picamera2')
+    logger = logging.getLogger("picamera2")
     logger.setLevel(logging.DEBUG)
     if not logger.handlers:
         console = logging.StreamHandler()
@@ -23,8 +23,8 @@ def initialize_logger(console_level):
             console.setLevel(logging.DEBUG)
         else:
             raise ValueError("Console level must be an int between 0-2.")
-        dtfmt = '%Y-%m-%dT%H:%M:%S'
-        strfmt = '%(asctime)s.%(msecs)03dZ | %(levelname)-8s | %(message)s'
+        dtfmt = "%Y-%m-%dT%H:%M:%S"
+        strfmt = "%(asctime)s.%(msecs)03dZ | %(levelname)-8s | %(message)s"
         console_fmt = logging.Formatter(strfmt, datefmt=dtfmt)
         console_fmt.converter = time.gmtime
         console.setFormatter(console_fmt)


### PR DESCRIPTION
A quick demo of how to make `black` auto-format everything. This also shifts format checking to gh infrastructure.

All I did to generate a bulk of the changes in this PR was:
`black picamera2` which in turn output the reformatted code:
![image](https://user-images.githubusercontent.com/579782/166849885-8d17da53-cbfd-4714-86a3-7d0df4a3ded1.png)

This has the side benefit of killing a lot of diff noise between PR's

Signed-off-by: Matthew Goodman <matt@exclosure.io>