### PR TITLE
Kill `import *` instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Readers are recommended to refer to the supplied [examples](#examples) in conjun
 The camera system should be opened as shown.
 
 ```
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2
 
 picam2 = Picamera2()
 ```
@@ -185,7 +185,7 @@ To start the event loop, the `start_preview` method should be called. It can be 
 Example:
 
 ```
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
@@ -198,7 +198,7 @@ picam2.start()
 
 Note that
 ```
-from picamera2.previews.qt_gl_preview import *
+from picamera2.previews.qt_gl_preview import QtGlPreview
 picam2.start_preview(QtGlPreview())
 ```
 is equivalent to `picam2.start_preview(Preview.QTGL)`.
@@ -223,7 +223,7 @@ Once the preview has been started using the `start_preview` method, an overlay m
 
 Overlays will always be stetched to cover the complete camera image. For example:
 ```
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2
 import numpy as np
 
 picam2 = Picamera2()

--- a/examples/app_capture.py
+++ b/examples/app_capture.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
 
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import *
+from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton, QVBoxLayout, QApplication, QWidget
 
-from picamera2.previews.q_gl_picamera2 import *
-from picamera2.picamera2 import *
+from picamera2.previews.q_gl_picamera2 import QGlPicamera2
+from picamera2.picamera2 import Picamera2
 
 
 def request_callback(request):

--- a/examples/app_capture2.py
+++ b/examples/app_capture2.py
@@ -5,10 +5,10 @@
 # when the capture, that is running asynchronously, is finished.
 
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import *
+from PyQt5.QtWidgets import QPushButton, QLabel, QHBoxLayout, QVBoxLayout, QApplication, QWidget
 
-from picamera2.previews.q_gl_picamera2 import *
-from picamera2.picamera2 import *
+from picamera2.previews.q_gl_picamera2 import QGlPicamera2
+from picamera2.picamera2 import Picamera2
 
 
 def request_callback(request):

--- a/examples/app_capture_request.py
+++ b/examples/app_capture_request.py
@@ -5,10 +5,10 @@
 # async_result field.
 
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import *
+from PyQt5.QtWidgets import QApplication, QPushButton, QLabel, QWidget, QHBoxLayout, QVBoxLayout
 
-from picamera2.previews.q_picamera2 import *
-from picamera2.picamera2 import *
+from picamera2.previews.q_picamera2 import QPicamera2
+from picamera2.picamera2 import Picamera2
 
 
 def request_callback(request):

--- a/examples/capture_circular.py
+++ b/examples/capture_circular.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python3
-
-from picamera2.encoders.h264_encoder import *
-from picamera2.picamera2 import *
 import time
-import os
+
+import numpy as np
+
+from picamera2.encoders.h264_encoder import H264Encoder, CircularOutput
+from picamera2.picamera2 import Picamera2
 
 lsize = (320, 240)
 picam2 = Picamera2()

--- a/examples/capture_full_res.py
+++ b/examples/capture_full_res.py
@@ -2,7 +2,7 @@
 
 # Capture a JPEG while still running in the preview mode.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/capture_headless.py
+++ b/examples/capture_headless.py
@@ -1,6 +1,6 @@
 #!//usr/bin/python3
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2
 
 picam2 = Picamera2()
 config = picam2.still_configuration()

--- a/examples/capture_image_full_res.py
+++ b/examples/capture_image_full_res.py
@@ -2,7 +2,7 @@
 
 # Capture a full resolution image to memory rather than to a file.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/capture_jpeg.py
+++ b/examples/capture_jpeg.py
@@ -3,7 +3,7 @@
 # Capture a JPEG while still running in the preview mode. When you
 # capture to a file, the return value is the metadata for that image.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/capture_mjpeg.py
+++ b/examples/capture_mjpeg.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
-
-from picamera2.encoders.jpeg_encoder import *
-from picamera2.picamera2 import *
 import time
+
+from picamera2.encoders.jpeg_encoder import JpegEncoder
+from picamera2.picamera2 import Picamera2
+
 
 picam2 = Picamera2()
 video_config = picam2.video_configuration(main={"size": (1920, 1080)})

--- a/examples/capture_motion.py
+++ b/examples/capture_motion.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
-from picamera2.encoders.h264_encoder import *
-from picamera2.picamera2 import *
+from picamera2.encoders.h264_encoder import H264Encoder
+from picamera2.picamera2 import Picamera2
 from signal import pause
 import numpy as np
 import time

--- a/examples/capture_png.py
+++ b/examples/capture_png.py
@@ -2,7 +2,7 @@
 
 # Capture a PNG while still running in the preview mode.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/capture_stream.py
+++ b/examples/capture_stream.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python3
 
-from picamera2.encoders.h264_encoder import *
-from picamera2.picamera2 import *
+
 import socket
 import time
-import os
+
+from picamera2.encoders.h264_encoder import H264Encoder, FileOutput
+from picamera2.picamera2 import Picamera2
 
 picam2 = Picamera2()
 video_config = picam2.video_configuration({"size": (1280, 720)})

--- a/examples/capture_video.py
+++ b/examples/capture_video.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python3
-
-from picamera2.encoders.h264_encoder import *
-from picamera2.picamera2 import *
 import time
-import os
+
+from picamera2.encoders.h264_encoder import H264Encoder
+from picamera2.picamera2 import Picamera2
 
 picam2 = Picamera2()
 video_config = picam2.video_configuration()

--- a/examples/controls.py
+++ b/examples/controls.py
@@ -3,7 +3,7 @@
 # Example of setting controls. Here, after one second, we fix the AGC/AEC
 # to the values it has reached whereafter it will no longer change.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/controls_2.py
+++ b/examples/controls_2.py
@@ -2,7 +2,7 @@
 
 # Another (simpler!) way to fix the AEC/AGC and AWB.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/exposure_fixed.py
+++ b/examples/exposure_fixed.py
@@ -2,7 +2,7 @@
 
 # Start camera with fixed exposure and gain.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/metadata.py
+++ b/examples/metadata.py
@@ -2,7 +2,7 @@
 
 # Obtain the current camera control values in the image metadata.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/metadata_with_image.py
+++ b/examples/metadata_with_image.py
@@ -3,7 +3,7 @@
 # Obtain an image from the camera along with the exact metadata that
 # that describes that image.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/mjpeg_server.py
+++ b/examples/mjpeg_server.py
@@ -4,8 +4,8 @@
 # Run this script, then point a web browser at http:<this-ip-address>:8000
 # Note: needs simplejpeg to be installed (pip3 install simplejpeg).
 
-from picamera2.picamera2 import *
-from picamera2.encoders.jpeg_encoder import *
+from picamera2.picamera2 import Picamera2
+from picamera2.encoders.jpeg_encoder import JpegEncoder, FileOutput
 import io
 import logging
 import socketserver

--- a/examples/opencv_face_detect.py
+++ b/examples/opencv_face_detect.py
@@ -2,7 +2,7 @@
 
 import cv2
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2
 
 # Grab images as numpy arrays and leave everything else to OpenCV.
 

--- a/examples/opencv_face_detect_2.py
+++ b/examples/opencv_face_detect_2.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
+import time
 
 import cv2
+import numpy as np
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 
 # This version creates a lores YUV stream, extracts the Y channel and runs the face
 # detector directly on that. We use the supplied OpenGL accelerated preview window

--- a/examples/opencv_mertens_merge.py
+++ b/examples/opencv_mertens_merge.py
@@ -1,9 +1,12 @@
 #!/usr/bin/python3
 
-import cv2
 import time
 
-from picamera2.picamera2 import *
+import cv2
+import numpy as np
+
+from picamera2.picamera2 import Picamera2
+
 
 # Simple Mertens merge with 3 exposures. No image alignment or anything fancy.
 RATIO = 3.0

--- a/examples/overlay_drm.py
+++ b/examples/overlay_drm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import numpy as np
 import time
 

--- a/examples/overlay_gl.py
+++ b/examples/overlay_gl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import numpy as np
 import time
 

--- a/examples/overlay_null.py
+++ b/examples/overlay_null.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
 
-from picamera2.picamera2 import *
-import numpy as np
 import time
+
+import numpy as np
+
+from picamera2.picamera2 import Picamera2
 
 picam2 = Picamera2()
 picam2.configure(picam2.preview_configuration())

--- a/examples/overlay_qt.py
+++ b/examples/overlay_qt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import numpy as np
 import time
 

--- a/examples/preview.py
+++ b/examples/preview.py
@@ -3,7 +3,7 @@
 # Normally the QtGlPreview implementation is recommended as it benefits
 # from GPU hardware acceleration.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/preview_drm.py
+++ b/examples/preview_drm.py
@@ -2,7 +2,7 @@
 
 # For use from the login console, when not running X Windows.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/preview_null.py
+++ b/examples/preview_null.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import time
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
 config = picam2.preview_configuration()

--- a/examples/preview_x_forwarding.py
+++ b/examples/preview_x_forwarding.py
@@ -3,7 +3,7 @@
 # The QtPreview uses software rendering and thus makes more use of the
 # CPU, but it does work with X forwarding, unlike the QtGlPreview.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/raw.py
+++ b/examples/raw.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 
 # Configure a raw stream and capture an image from it.
-
-from picamera2.picamera2 import *
 import time
+
+from picamera2.picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)

--- a/examples/rotation.py
+++ b/examples/rotation.py
@@ -1,9 +1,11 @@
 #!/usr/bin/python3
 
 # Run the camera with a 180 degree rotation.
-
-from picamera2.picamera2 import *
 import time
+
+import libcamera
+
+from picamera2.picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)

--- a/examples/still_during_video.py
+++ b/examples/still_during_video.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
-from picamera2.encoders.h264_encoder import *
-from picamera2.picamera2 import *
+from picamera2.encoders.h264_encoder import H264Encoder
+from picamera2.picamera2 import Picamera2
 import time
 import os
 

--- a/examples/switch_mode.py
+++ b/examples/switch_mode.py
@@ -2,7 +2,7 @@
 
 # Switch from preview to full resolution mode.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/switch_mode_2.py
+++ b/examples/switch_mode_2.py
@@ -2,7 +2,7 @@
 
 # Switch from preview to full resolution mode (alternative method).
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/tensorflow/real_time.py
+++ b/examples/tensorflow/real_time.py
@@ -32,7 +32,7 @@ import numpy as np
 from PIL import Image
 from PIL import ImageFont, ImageDraw
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 
 normalSize = (640, 480)
 lowresSize = (320, 240)

--- a/examples/tensorflow/real_time_with_labels.py
+++ b/examples/tensorflow/real_time_with_labels.py
@@ -32,7 +32,7 @@ import numpy as np
 from PIL import Image
 from PIL import ImageFont, ImageDraw
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 
 normalSize = (640, 480)
 lowresSize = (320, 240)

--- a/examples/tuning_file.py
+++ b/examples/tuning_file.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
+import time
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 
 # Here we load up the tuning for the HQ cam and alter the default exposure profile.
 # For more information on what can be changed, see chapter 5 in

--- a/examples/window_offset.py
+++ b/examples/window_offset.py
@@ -2,7 +2,7 @@
 
 # Create a preview window at a particular location on the display.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/examples/yuv_to_rgb.py
+++ b/examples/yuv_to_rgb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
-from picamera2.picamera2 import *
-from picamera2.converters import *
+from picamera2.picamera2 import Picamera2
+from picamera2.converters import YUV420_to_RGB
 import cv2
 
 cv2.startWindowThread()

--- a/examples/zoom.py
+++ b/examples/zoom.py
@@ -2,7 +2,7 @@
 
 # How to do digital zoom using the "ScalerCrop" control.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 picam2 = Picamera2()

--- a/picamera2/encoders/encoder.py
+++ b/picamera2/encoders/encoder.py
@@ -1,7 +1,5 @@
 from v4l2 import *
 from .output import *
-import collections
-import io
 
 
 class Encoder:

--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -1,18 +1,13 @@
-import picamera2
-import selectors
 import threading
 import queue
-import atexit
 import fcntl
 import mmap
 import select
-import time
-from picamera2.encoders.encoder import *
+from picamera2.encoders.encoder import Encoder
 from v4l2 import *
 
 
 class H264Encoder(Encoder):
-
     def __init__(self, bitrate, repeat=False):
         super().__init__()
         self.bufs = {}

--- a/picamera2/encoders/jpeg_encoder.py
+++ b/picamera2/encoders/jpeg_encoder.py
@@ -1,5 +1,6 @@
-from picamera2.encoders.multi_encoder import *
 import simplejpeg
+
+from picamera2.encoders.multi_encoder import MultiEncoder
 
 
 class JpegEncoder(MultiEncoder):

--- a/picamera2/encoders/multi_encoder.py
+++ b/picamera2/encoders/multi_encoder.py
@@ -1,7 +1,8 @@
-from picamera2.encoders.encoder import *
-import threading
-import queue
 from concurrent.futures import ThreadPoolExecutor
+import queue
+import threading
+
+from picamera2.encoders.encoder import Encoder
 
 
 class MultiEncoder(Encoder):

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -2,15 +2,14 @@
 
 # Start a Qt application, and use an asynchronous thread to "click" on the GUI.
 
-import sys
 import time
 import threading
 
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtWidgets import *
+from PyQt5.QtWidgets import QLabel, QWidget, QHBoxLayout, QVBoxLayout, QPushButton, QApplication
 
-from picamera2.previews.q_gl_picamera2 import *
-from picamera2.picamera2 import *
+from picamera2.previews.q_gl_picamera2 import QGlPicamera2
+from picamera2.picamera2 import Picamera2
 
 
 def request_callback(request):

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -1,4 +1,6 @@
-from picamera2.picamera2 import *
+import time
+
+from picamera2.picamera2 import Picamera2, Preview
 
 def main():
     print("With context...")

--- a/tests/drm_preview_test.py
+++ b/tests/drm_preview_test.py
@@ -2,7 +2,7 @@
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
 
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 preview_type = Preview.DRM

--- a/tests/preview_cycle_test.py
+++ b/tests/preview_cycle_test.py
@@ -1,4 +1,4 @@
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 

--- a/tests/preview_location_test.py
+++ b/tests/preview_location_test.py
@@ -1,4 +1,4 @@
-from picamera2.picamera2 import *
+from picamera2.picamera2 import Picamera2, Preview
 import time
 
 print("Preview re-initialized after start.")

--- a/tests/qt_gl_preview_test.py
+++ b/tests/qt_gl_preview_test.py
@@ -2,8 +2,9 @@
 
 # Test that we can successfully close a QtGlPreview window and open a new one.
 
-from picamera2.picamera2 import *
 import time
+
+from picamera2.picamera2 import Picamera2, Preview
 
 preview_type = Preview.QTGL
 

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -50,6 +50,21 @@ def clean_directory():
         os.remove(os.path.join(cwd, f))
 
 
+def indent(text, num_spaces=4):
+    between = "\n" + " " * num_spaces
+    return between.join(text.splitlines()) + "\n"
+
+
+def print_subprocess_output(exc: subprocess.CalledProcessError):
+    if exc.stdout is not None:
+        print("=" * 20 + "    STDOUT    " + "=" * 20)
+        print(indent(exc.stdout.decode('utf-8')))
+
+    if exc.stderr is not None:
+        print("=" * 20 + "    STDERR    " + "=" * 20)
+        print(indent(exc.stderr.decode('utf-8')))
+
+
 def run_tests(tests):
     """Run all the given tests. Return the number that fail."""
     num_failed = 0
@@ -77,11 +92,13 @@ def run_tests(tests):
                     break
             if test_passed:
                 print("\tPASSED")
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
             print("\tFAILED")
+            print_subprocess_output(e)
             num_failed = num_failed + 1
         except subprocess.TimeoutExpired:
             print("\tTIMED OUT")
+            print_subprocess_output(e)
             num_failed = num_failed + 1
     return num_failed
 


### PR DESCRIPTION
This PR does two things:
- removes a majority of star imports from codebase. For a lengthy set of examples for why this is a good idea, checkout this [SO post](https://stackoverflow.com/questions/2386714/why-is-import-bad). 
- Adds stdout and stderr reporting from tests.

This leaves star imports in a few places:
- Submodules that import a slew of V4L2 symbols
- Submodules that used the OpenGL.**.* structures
These seem pretty hairy, but well contained.

Incidentally, this helped find/discover a number of places where `np`, `time`, and `os` were imported by proxy and thusly fragile.