### PR TITLE
New FfmpegOutput class allows writing of mp4 files and audio streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Finally fetch the *Picamera2* repository. There are some dependencies to downloa
 ```
 cd
 sudo pip3 install pyopengl piexif simplejpeg PiDNG
-sudo apt install -y python3-pyqt5 python3-numpy
+sudo apt install -y python3-pyqt5 python3-numpy python3-prctl ffmpeg
 git clone https://github.com/raspberrypi/picamera2.git
 ```
 
@@ -40,6 +40,12 @@ To make everything run, you will also have to set your `PYTHONPATH` environment 
 ```
 export PYTHONPATH=/home/pi/picamera2
 ```
+
+#### FFmpeg
+
+We have suggested installing _FFmpeg_ in order to use _Picamera2_. It is, however, only required to support certain complex file types, such as writing output to _mp4_ files. If you do not require this functionality then _FFmpeg_ is not required, and you should avoid trying to use the `FfmpegOutput` class.
+
+We note that it is installed by default in Raspberry Pi OS, but not in Raspberry Pi OS Lite.
 
 #### OpenCV
 
@@ -339,6 +345,7 @@ Finally, for more advanced use cases:
 - To capture raw camera buffers, please see [`raw.py`](#rawpy).
 - For an example of how you might capture and stream h.264 video over the network, please check [`capture_stream.py`](#capture_streampy).
 - To capture a DNG and JPEG file concurrently (that is, the JPEG is made from the same raw data is the DNG), please look at [`capture_dng_and_jpeg.py`](#capture_dng_and_jpegpy).
+- Users wishing to capture mp4 files (rather than raw h.264 streams) should check out [`mp4_capture.py`](#mp4_capturepy). There's also an example showing how to record an audio stream.
 
 ### [capture_dng_and_jpeg.py](example/capture_dng_and_jpeg.py)
 
@@ -411,6 +418,12 @@ This is a simple MJPEG web server, derived from one of the old [*Picamera exampl
 At some point in the future *Picamera2* may include built-in support for JPEG encoding, so this example is certainly liable to change.
 
 To try it, just start the server on your Pi and then, on a different computer open a web browser and visit `http://<your-Pi's-IP-address>:8000`.
+
+### [mp4_capture.py](examples/mp4_capture.py)
+
+We can use _FFmpeg_ to save videos to mp4 format files, rather than as raw h.264 bitstreams, as shown in this example. _FFmpeg_ also allows us to record an audio stream with the video, as shown [here](examples/audio_video_capture.py).
+
+Using _FFmpeg_ like this leaves the audio/video sync somewhat in the hands of the video encoder and _FFmpeg_ itself, so you may in general find you need to tweak it slightly depending on your precise use case and configuration. The `FfmpegOutput` class has an `audio_sync` parameter that allows you to do this.
 
 ### [opencv_face_detect.py](examples/opencv_face_detect.py)
 

--- a/examples/audio_video_capture.py
+++ b/examples/audio_video_capture.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+import time
+
+from picamera2.encoders import H264Encoder
+from picamera2.outputs import FfmpegOutput
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+video_config = picam2.video_configuration()
+picam2.configure(video_config)
+
+encoder = H264Encoder(10000000)
+output = FfmpegOutput('test.mp4', audio=True)
+
+picam2.start_recording(encoder, output)
+time.sleep(10)
+picam2.stop_recording()

--- a/examples/mp4_capture.py
+++ b/examples/mp4_capture.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+import time
+
+from picamera2.encoders import H264Encoder
+from picamera2.outputs import FfmpegOutput
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+video_config = picam2.video_configuration()
+picam2.configure(video_config)
+
+encoder = H264Encoder(10000000)
+output = FfmpegOutput('test.mp4')
+
+picam2.start_recording(encoder, output)
+time.sleep(10)
+picam2.stop_recording()

--- a/picamera2/outputs/__init__.py
+++ b/picamera2/outputs/__init__.py
@@ -1,3 +1,4 @@
 from .output import Output
 from .fileoutput import FileOutput
 from .circularoutput import CircularOutput
+from .ffmpegoutput import FfmpegOutput

--- a/picamera2/outputs/ffmpegoutput.py
+++ b/picamera2/outputs/ffmpegoutput.py
@@ -1,0 +1,84 @@
+import prctl
+import signal
+import subprocess
+
+from .output import Output
+
+
+class FfmpegOutput(Output):
+    """
+    The FfmpegOutput class allows an encoded video stream to be passed to FFmpeg for output,
+    meaning we can take advantange of FFmpeg's wide support for different output formats.
+    Optionally audio recording may be included, where this is handled entirely by FFmpeg.
+
+    Because we are prepared to accept whatever parameters and values that FFmpeg supports,
+    there is generally no checking up at this level. That may change over time as we
+    develop better expectations as to what can and cannot work.
+
+    For example, to record an mp4 file use FfmpegOutput("test.mp4")
+    To include audio in the recording, use FfmpegOutput("test.mp4", audio=True)
+    To record an MPEG2 transport stream, use FfmpegOutput("test.ts")
+    In fact, the output filename may include any string of options and an output
+    destination so long as these are meaningful to FFmpeg. So you might even try something
+    like FfmpegOutput("-f mpegts udp://<ip-addr>:<port>").
+
+    When audio recording is enabled, the following optional parameters are available:
+    audio_device - the name of the Pulse audio device ("default" is usually OK)
+    audio_sync - time offset (in seconds) to add to the audio stream to ensure
+        synchronisation with the video. So making this more negative will make the
+        audio earlier. In general this may need tweaking depending on the hardware
+        and configuration being used.
+    audio_samplerate, audio_codec, audio_bitrate - the usual audio parameters.
+
+    """
+    def __init__(self, output_filename, audio=False, audio_device="default", audio_sync=-0.3,
+                 audio_samplerate=48000, audio_codec="aac", audio_bitrate=128000):
+        super().__init__()
+        self.ffmpeg = None
+        self.output_filename = output_filename
+        self.audio = audio
+        self.audio_device = audio_device
+        self.audio_sync = audio_sync
+        self.audio_samplerate = audio_samplerate
+        self.audio_codec = audio_codec
+        self.audio_bitrate = audio_bitrate
+
+    def start(self):
+        general_options = ['-loglevel', 'warning',
+                           '-y']  # -y means overwrite output without asking
+        # We have to get FFmpeg to timestamp the video frames as it gets them. This isn't
+        # ideal because we're likely to pick up some jitter, but works passably, and I
+        # don't have a better alternative right now.
+        video_input = ['-use_wallclock_as_timestamps', '1',
+                       '-thread_queue_size', '32',  # necessary to prevent warnings
+                       '-i', '-']
+        video_codec = ['-c:v', 'copy']
+        audio_input = []
+        audio_codec = []
+        if self.audio:
+            audio_input = ['-itsoffset', str(self.audio_sync),
+                           '-f', 'pulse',
+                           '-sample_rate', str(self.audio_bitrate),
+                           '-thread_queue_size', '512',  # necessary to prevent warnings
+                           '-i', self.audio_device]
+            audio_codec = ['-b:a', str(self.audio_bitrate),
+                           '-c:a', self.audio_codec]
+
+        command = ['ffmpeg'] + general_options + audio_input + video_input + \
+            audio_codec + video_codec + self.output_filename.split()
+        # The preexec_fn is a slightly nasty way of ensuring FFmpeg gets stopped if we quit
+        # without calling stop() (which is otherwise not guaranteed).
+        self.ffmpeg = subprocess.Popen(command, stdin=subprocess.PIPE, preexec_fn=lambda: prctl.set_pdeathsig(signal.SIGKILL))
+        super().start()
+
+    def stop(self):
+        super().stop()
+        if self.ffmpeg is not None:
+            self.ffmpeg.stdin.close()  # FFmpeg needs this to shut down tidily
+            self.ffmpeg.terminate()
+            self.ffmpeg = None
+
+    def outputframe(self, frame, keyframe=True):
+        if self.recording:
+            self.ffmpeg.stdin.write(frame)
+            self.ffmpeg.stdin.flush()  # forces every frame to get timestamped individually

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -9,6 +9,7 @@ examples/controls.py
 examples/controls_2.py
 examples/exposure_fixed.py
 examples/metadata.py
+examples/mp4_capture.py
 examples/opencv_face_detect_2.py
 examples/opencv_mertens_merge.py
 examples/overlay_gl.py


### PR DESCRIPTION
This pair of commits adds a new `FfmpegOutput` class. It allows the encoded video stream to be sent to _FFmpeg_ for output, allowing it to be muxed into various different types of container, including _mp4_ files. You can even get _FFmpeg_ to record an audio stream into the output file.

This is perhaps a little bit experimental in that there's so much stuff that you could do with _FFmpeg_, it's hard to know where to draw the line as to what folks should be able to try and what you might reasonably expect to work. I also know of no easy way to get precise timestamps (that _Picamera2_ has) into _FFmpeg_, so I'm having to let it resample those which will doubtless incur some jitter.

Still, on balance it seems to work pretty well, and _mp4_ files and audio are a good feature to have.

The first commit implements the new class, the second adds examples and updates documentation. Note that there's a new dependency to install (`sudo apt install -y python3-prctl`). Can we assume _FFmpeg_ is installed on all Pis? That's also something to check, though it would only fall over if you try to use the class.