### PR TITLE
Improve yuv_to_rgb.py example

### DIFF
--- a/examples/yuv_to_rgb.py
+++ b/examples/yuv_to_rgb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from picamera2 import Picamera2, YUV420_to_RGB
+from picamera2 import Picamera2
 import cv2
 
 cv2.startWindowThread()
@@ -11,6 +11,6 @@ picam2.configure(config)
 picam2.start()
 
 while True:
-    buffer = picam2.capture_buffer("lores")
-    rgb = YUV420_to_RGB(buffer, (640, 480))
+    yuv420 = picam2.capture_array("lores")
+    rgb = cv2.cvtColor(yuv420, cv2.COLOR_YUV420p2RGB)
     cv2.imshow("Camera", rgb)

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -78,6 +78,12 @@ class CompletedRequest:
                 array = array.reshape((h, stride))
                 array = np.asarray(array[:, :w * 4], order='C')
             image = array.reshape((h, w, 4))
+        elif fmt in ("YUV420", "YVU420"):
+            # Returning YUV420 as an image of 50% greater height (the extra bit continaing
+            # the U/V data) is useful because OpenCV can convert it to RGB for us quite
+            # efficiently. We leave any packing in there, however, as it would be easier
+            # to remove that after conversion to RGB (if that's what the caller does).
+            image = array.reshape((h * 3 // 2, stride))
         elif fmt[0] == 'S':  # raw formats
             image = array.reshape((h, stride))
         else:


### PR DESCRIPTION
When OpenCV is available, it has more efficient YUV420 to RGB
conversion functions which you may be able to use. Documentation for
this example also updated.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>