### PR TITLE
Fix some Qt complaints caused by the location of various imports

### DIFF
--- a/examples/app_capture.py
+++ b/examples/app_capture.py
@@ -3,7 +3,7 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton, QVBoxLayout, QApplication, QWidget
 
-from picamera2.previews import QGlPicamera2
+from picamera2.previews.qt import QGlPicamera2
 from picamera2 import Picamera2
 
 

--- a/examples/app_capture2.py
+++ b/examples/app_capture2.py
@@ -7,7 +7,7 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtWidgets import QPushButton, QLabel, QHBoxLayout, QVBoxLayout, QApplication, QWidget
 
-from picamera2.previews import QGlPicamera2
+from picamera2.previews.qt import QGlPicamera2
 from picamera2 import Picamera2
 
 

--- a/picamera2/previews/__init__.py
+++ b/picamera2/previews/__init__.py
@@ -1,5 +1,3 @@
 from .drm_preview import DrmPreview
 from .null_preview import NullPreview
-from .q_picamera2 import QPicamera2
-from .q_gl_picamera2 import EglState, QGlPicamera2
 from .qt_previews import QtPreview, QtGlPreview

--- a/picamera2/previews/qt.py
+++ b/picamera2/previews/qt.py
@@ -1,0 +1,2 @@
+from .q_picamera2 import QPicamera2
+from .q_gl_picamera2 import EglState, QGlPicamera2

--- a/picamera2/previews/qt_previews.py
+++ b/picamera2/previews/qt_previews.py
@@ -16,8 +16,6 @@ class QtPreviewBase:
         from PyQt5.QtCore import Qt
         from PyQt5.QtWidgets import QApplication
 
-        from picamera2.previews.q_picamera2 import QApplication, QPicamera2, Qt
-
         self.app = QApplication([])
         self.size = (self.width, self.height)
         self.qpicamera2 = self.make_picamera2_widget(picam2, width=self.width, height=self.height)
@@ -62,7 +60,7 @@ class QtPreviewBase:
 
 class QtPreview(QtPreviewBase):
     def make_picamera2_widget(self, picam2, width=640, height=480):
-        from picamera2.previews.q_picamera2 import QPicamera2
+        from picamera2.previews.qt import QPicamera2
         return QPicamera2(picam2, width=self.width, height=self.height)
 
     def get_title(self):
@@ -71,7 +69,7 @@ class QtPreview(QtPreviewBase):
 
 class QtGlPreview(QtPreviewBase):
     def make_picamera2_widget(self, picam2, width=640, height=480):
-        from picamera2.previews.q_gl_picamera2 import QGlPicamera2
+        from picamera2.previews.qt import QGlPicamera2
         return QGlPicamera2(picam2, width=self.width, height=self.height)
 
     def get_title(self):

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -8,7 +8,7 @@ import threading
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtWidgets import QLabel, QWidget, QHBoxLayout, QVBoxLayout, QPushButton, QApplication
 
-from picamera2.previews import QGlPicamera2
+from picamera2.previews.qt import QGlPicamera2
 from picamera2 import Picamera2
 
 


### PR DESCRIPTION
Qt is really picky about importing stuff in a thread other than the
one in which you want to run its event loop. The recent import tidying
has left behind some "WARNING: QApplication was not created in the
main() thread" messages when starting the Qt preview windows.

This change moves the Qt imports out of previews/__init__.py and puts
them into previews/qt.py so that we still have a reasonably tidy way
to import them when necessary. The examples and tests, and also
previews/qt_previews.py, have been tidied to use this new import path.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>