### PR TITLE
An extra recording example

### DIFF
--- a/examples/app_recording.py
+++ b/examples/app_recording.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton, QVBoxLayout, QApplication, QWidget
+
+from picamera2.previews.qt import QGlPicamera2
+from picamera2.encoders import H264Encoder
+from picamera2.outputs import FileOutput
+from picamera2 import Picamera2
+
+
+def request_callback(request):
+    label.setText(''.join("{}: {}\n".format(k, v) for k, v in request.get_metadata().items()))
+
+
+picam2 = Picamera2()
+picam2.request_callback = request_callback
+picam2.configure(picam2.video_configuration(main={"size": (1280, 720)}))
+
+app = QApplication([])
+
+
+def on_button_clicked():
+    global recording
+    if not recording:
+        encoder = H264Encoder(10000000)
+        encoder.output = FileOutput("test.h264")
+        picam2.start_encoder(encoder)
+        button.setText("Stop recording")
+        recording = True
+    else:
+        picam2.stop_encoder()
+        button.setText("Start recording")
+        recording = False
+
+
+qpicamera2 = QGlPicamera2(picam2, width=800, height=480)
+button = QPushButton("Start recording")
+button.clicked.connect(on_button_clicked)
+label = QLabel()
+window = QWidget()
+window.setWindowTitle("Qt Picamera2 App")
+recording = False
+
+label.setFixedWidth(400)
+label.setAlignment(QtCore.Qt.AlignTop)
+layout_h = QHBoxLayout()
+layout_v = QVBoxLayout()
+layout_v.addWidget(label)
+layout_v.addWidget(button)
+layout_h.addWidget(qpicamera2, 80)
+layout_h.addLayout(layout_v, 20)
+window.resize(1200, 480)
+window.setLayout(layout_h)
+
+picam2.start()
+window.show()
+app.exec()

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -914,7 +914,9 @@ class Picamera2:
         if wait:
             return self.wait()
 
-    def start_encoder(self) -> None:
+    def start_encoder(self, encoder=None) -> None:
+        if encoder is not None:
+            self.encoder = encoder
         streams = self.camera_configuration()
         if self.encoder is None:
             raise RuntimeError("No encoder specified")


### PR DESCRIPTION
@chrisruk Are you OK with this (very) little API enhancement? In the 2nd of the two commits I added a little Qt recording app example which was in response to a forum question. I felt that always doing `picam2.encoder = encoder` seemed a bit verbose and that it might be nice to allow it to be passed in the `start_encoder` method. (Alternatively, we could always force the encoder to be passed...) Anyway let me know what you think!