### PR TITLE
Remove controls parameter from start method

### DIFF
--- a/examples/exposure_fixed.py
+++ b/examples/exposure_fixed.py
@@ -7,9 +7,9 @@ import time
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
-
-preview_config = picam2.preview_configuration()
+controls = {"ExposureTime": 10000, "AnalogueGain": 1.0}
+preview_config = picam2.preview_configuration(controls=controls)
 picam2.configure(preview_config)
 
-picam2.start({"ExposureTime": 10000, "AnalogueGain": 1.0})
+picam2.start()
 time.sleep(5)

--- a/examples/opencv_mertens_merge.py
+++ b/examples/opencv_mertens_merge.py
@@ -21,20 +21,24 @@ metadata = picam2.capture_metadata()
 exposure_normal = metadata["ExposureTime"]
 gain = metadata["AnalogueGain"] * metadata["DigitalGain"]
 picam2.stop()
-
-capture_config = picam2.preview_configuration(main={"size": (1024, 768), "format": "RGB888"})
+controls = {"ExposureTime": exposure_normal, "AnalogueGain": gain}
+capture_config = picam2.preview_configuration(main={"size": (1024, 768),
+                                                    "format": "RGB888"},
+                                              controls=controls)
 picam2.configure(capture_config)
-picam2.start({"ExposureTime": exposure_normal, "AnalogueGain": gain})
+picam2.start()
 normal = picam2.capture_array()
 picam2.stop()
 
 exposure_short = int(exposure_normal / RATIO)
-picam2.start({"ExposureTime": exposure_short, "AnalogueGain": gain})
+picam2.set_controls({"ExposureTime": exposure_short, "AnalogueGain": gain})
+picam2.start()
 short = picam2.capture_array()
 picam2.stop()
 
 exposure_long = int(exposure_normal * RATIO)
-picam2.start({"ExposureTime": exposure_long, "AnalogueGain": gain})
+picam2.set_controls({"ExposureTime": exposure_long, "AnalogueGain": gain})
+picam2.start()
 long = picam2.capture_array()
 picam2.stop()
 


### PR DESCRIPTION
Instead, applications can call set_controls after calling configure
and before calling start. Updated relevant examples to match.

Signed-off-by: Ian Black <blackia@oregonstate.edu>
Signed-off-by: David Plowman <david.plowman@raspberrypi.com>