### PR TITLE
Better error checking of the stream configuration

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -240,10 +240,12 @@ class Picamera2:
         # Take an initial stream_config and add any user updates.
         if updates is None:
             return None
-        if "format" in updates:
-            stream_config["format"] = updates["format"]
-        if "size" in updates:
-            stream_config["size"] = updates["size"]
+        valid = ("format", "size")
+        for key, value in updates.items():
+            if key in valid:
+                stream_config[key] = value
+            else:
+                raise ValueError(f"Bad key '{key}': valid stream configuration keys are {valid}")
         return stream_config
 
     def add_display_and_encode(self, config, display, encode) -> None:


### PR DESCRIPTION
Complain if any unexpected keys are found. This will help to warn
users who mistakenly put camera controls into the stream
configuration.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>