### PR TITLE
Properly sync audio

### DIFF
--- a/picamera2/outputs/ffmpegoutput.py
+++ b/picamera2/outputs/ffmpegoutput.py
@@ -60,6 +60,7 @@ class FfmpegOutput(Output):
                            '-f', 'pulse',
                            '-sample_rate', str(self.audio_bitrate),
                            '-thread_queue_size', '512',  # necessary to prevent warnings
+                           '-use_wallclock_as_timestamps', '1',
                            '-i', self.audio_device]
             audio_codec = ['-b:a', str(self.audio_bitrate),
                            '-c:a', self.audio_codec]


### PR DESCRIPTION
This properly syncs up audio, by using `-use_wallclock_as_timestamps 1` for both audio _and_ stdin video input streams. This makes it easier for ffmpeg to sync audio. And I _think_ we can remove `-itsoffset` here also, at least it was possible in a project of [mine](https://github.com/autosbc/rpidashcam/blob/master/dashcam.py#L284) (based on mmalobj.py)  