### PR TITLE
Make file saving methods accept file-like objects as well as filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 ### Added
 
+* Methods that allow still captures to be saved to files have been updated to accept file-like objects, such as BytesIO.
 * NOGUI=1 environmental variable to install without GUI dependencies
 * The Picamera2's request_callback has been changed to post_callback. A new pre_callback has been added which runs before images copied for applications.
 * Support for multiple outputs for the encoder
+
+### Changed
 
 ## 0.2.1 Alpha Release
 

--- a/examples/capture_dng_and_jpeg.py
+++ b/examples/capture_dng_and_jpeg.py
@@ -16,5 +16,5 @@ picam2.start()
 time.sleep(2)
 
 r = picam2.switch_mode_capture_request_and_stop(capture_config)
-r.save(name="main", filename="full.jpg")
-r.save_dng(filename="full.dng")
+r.save("main", "full.jpg")
+r.save_dng("full.dng")

--- a/examples/capture_to_buffer.py
+++ b/examples/capture_to_buffer.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+from picamera2 import Picamera2
+import io
+import time
+
+picam2 = Picamera2()
+capture_config = picam2.still_configuration()
+picam2.configure(picam2.preview_configuration())
+picam2.start()
+
+time.sleep(1)
+data = io.BytesIO()
+picam2.capture_file(data, format='jpeg')
+print(data.getbuffer().nbytes)
+
+time.sleep(1)
+data = io.BytesIO()
+picam2.switch_mode_and_capture_file(capture_config, data, format='jpeg')
+print(data.getbuffer().nbytes)

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -4,6 +4,7 @@ examples/capture_full_res.py
 examples/capture_headless.py
 examples/capture_mjpeg.py
 examples/capture_png.py
+examples/capture_to_buffer.py
 examples/capture_video.py
 examples/controls.py
 examples/controls_2.py


### PR DESCRIPTION
This includes functions like capture_file,
switch_mode_and_capture_file etc. When passing a file object a format
parameter must be supplied, indicating what type of file is to be
saved.

Where appropriate, the filename variable has been renamed to
file_output, necessitating a correction to one of the examples.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>