### PR TITLE
Preview rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Changed
 
+* The preview window implementations are changed to preserve image aspect ratios which they did not previously. The Qt variants also respect resize events.
+
 ## 0.2.1 Alpha Release
 
 ### Added

--- a/examples/app_capture.py
+++ b/examples/app_capture.py
@@ -26,7 +26,7 @@ def on_button_clicked():
         print("Busy!")
 
 
-qpicamera2 = QGlPicamera2(picam2, width=800, height=600)
+qpicamera2 = QGlPicamera2(picam2, width=800, height=600, keep_ar=False)
 button = QPushButton("Click to capture JPEG")
 button.clicked.connect(on_button_clicked)
 label = QLabel()

--- a/examples/app_capture2.py
+++ b/examples/app_capture2.py
@@ -32,7 +32,7 @@ def capture_done():
     button.setEnabled(True)
 
 
-qpicamera2 = QGlPicamera2(picam2, width=800, height=600)
+qpicamera2 = QGlPicamera2(picam2, width=800, height=600, keep_ar=False)
 button = QPushButton("Click to capture JPEG")
 label = QLabel()
 window = QWidget()

--- a/examples/app_capture_overlay.py
+++ b/examples/app_capture_overlay.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton, QVBoxLayout, QApplication, QWidget, QCheckBox
+import numpy as np
+
+from picamera2.previews.qt import QPicamera2, QGlPicamera2
+from picamera2 import Picamera2
+
+
+def request_callback(request):
+    label.setText(''.join("{}: {}\n".format(k, v)
+                          for k, v in request.get_metadata().items()))
+
+
+def cleanup():
+    picam2.post_callback = None
+
+
+picam2 = Picamera2()
+picam2.post_callback = request_callback
+picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+app = QApplication([])
+
+
+def on_button_clicked():
+    if not picam2.async_operation_in_progress:
+        cfg = picam2.still_configuration()
+        picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False,
+                                            signal_function=None)
+    else:
+        print("Busy!")
+
+
+overlay = np.zeros((300, 400, 4), dtype=np.uint8)
+overlay[:150, 200:] = (255, 0, 0, 64)
+overlay[150:, :200] = (0, 255, 0, 64)
+overlay[150:, 200:] = (0, 0, 255, 64)
+
+
+def on_checkbox_toggled(checked):
+    if checked:
+        qpicamera2.set_overlay(overlay)
+    else:
+        qpicamera2.set_overlay(None)
+
+
+# Either camera widget implementation should work:
+# qpicamera2 = QPicamera2(picam2, width=800, height=600)
+# or:
+qpicamera2 = QGlPicamera2(picam2, width=800, height=600)
+
+button = QPushButton("Click to capture JPEG")
+button.clicked.connect(on_button_clicked)
+label = QLabel()
+checkbox = QCheckBox("Set Overlay", checked=False)
+checkbox.toggled.connect(on_checkbox_toggled)
+window = QWidget()
+window.setWindowTitle("Qt Picamera2 App")
+
+label.setFixedWidth(400)
+label.setAlignment(QtCore.Qt.AlignTop)
+layout_h = QHBoxLayout()
+layout_v = QVBoxLayout()
+layout_v.addWidget(label)
+layout_v.addWidget(checkbox)
+layout_v.addWidget(button)
+layout_h.addWidget(qpicamera2, 80)
+layout_h.addLayout(layout_v, 20)
+window.resize(1200, 600)
+window.setLayout(layout_h)
+
+picam2.start()
+window.show()
+app.exec()
+picam2.stop()

--- a/examples/app_recording.py
+++ b/examples/app_recording.py
@@ -34,7 +34,7 @@ def on_button_clicked():
         recording = False
 
 
-qpicamera2 = QGlPicamera2(picam2, width=800, height=480)
+qpicamera2 = QGlPicamera2(picam2, width=800, height=480, keep_ar=False)
 button = QPushButton("Start recording")
 button.clicked.connect(on_button_clicked)
 label = QLabel()

--- a/examples/preview_drm.py
+++ b/examples/preview_drm.py
@@ -8,7 +8,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.DRM, x=100, y=100, width=640, height=480)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.preview_configuration({"size": (640, 360)})
 picam2.configure(preview_config)
 
 picam2.start()

--- a/picamera2/previews/drm_preview.py
+++ b/picamera2/previews/drm_preview.py
@@ -110,6 +110,15 @@ class DrmPreview(NullPreview):
 
         drmfb = self.drmfbs[fb]
         x, y, w, h = self.window
+        # Letter/pillar-box to preserve the image's aspect ratio.
+        if width * h > w * height:
+            new_h = w * height // width
+            y += (h - new_h) // 2
+            h = new_h
+        else:
+            new_w = h * width // height
+            x += (w - new_w) // 2
+            w = new_w
         self.crtc.set_plane(self.plane, drmfb, x, y, w, h, 0, 0, width, height)
         # An "atomic commit" would probably be better, but I can't get this to work...
         # ctx = pykms.AtomicReq(self.card)

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -22,8 +22,10 @@ class NullPreview:
         # be a drop-in replacement for the Qt/DRM previews.
         self.size = (width, height)
         self.event = threading.Event()
+        self.picam2 = None
 
     def start(self, picam2):
+        self.picam2 = picam2
         self.thread = threading.Thread(target=self.thread_func, args=(picam2,))
         self.thread.setDaemon(True)
         self.running = True
@@ -42,3 +44,4 @@ class NullPreview:
     def stop(self):
         self.running = False
         self.thread.join()
+        self.picam2 = None

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -1,5 +1,6 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import pyqtSlot, QSocketNotifier, Qt, pyqtSignal
+from PyQt5.QtGui import QColor, QPainter, QPixmap, QImage
 from PyQt5.QtWidgets import QWidget, QApplication, QLabel
 from PIL import Image
 from PIL.ImageQt import ImageQt
@@ -8,18 +9,24 @@ import numpy as np
 
 class QPicamera2(QWidget):
     done_signal = pyqtSignal()
+    update_overlay_signal = pyqtSignal(object)
 
-    def __init__(self, picam2, parent=None, width=640, height=480):
+    def __init__(self, picam2, parent=None, width=640, height=480, bg_colour=(20, 20, 20), keep_ar=True):
         super().__init__(parent=parent)
         self.picamera2 = picam2
         picam2.have_event_loop = True
+        self.bg_colour = bg_colour
+        self.keep_ar = keep_ar
+        self.pil_img = None
+        self.pil_img_resized = None
         self.label = QLabel(self)
         self.label.resize(width, height)
         self.overlay = None
-        self.painter = QtGui.QPainter()
+        self.overlay_resized = None
+        self.painter = QPainter()
+        self.update_overlay_signal.connect(self.update_overlay)
         self.camera_notifier = QSocketNotifier(self.picamera2.camera_manager.efd,
-                                               QtCore.QSocketNotifier.Read,
-                                               self)
+                                               QSocketNotifier.Read, self)
         self.camera_notifier.activated.connect(self.handle_requests)
 
     def cleanup(self):
@@ -31,19 +38,83 @@ class QPicamera2(QWidget):
 
     def set_overlay(self, overlay):
         if overlay is not None:
-            # Better to resize the overlay here rather than in the rendering loop.
-            orig = overlay
-            overlay = np.ascontiguousarray(overlay)
+            overlay = np.copy(overlay, order='C')
             shape = overlay.shape
-            size = self.label.size()
-            if orig is overlay and shape[1] == size.width() and shape[0] == size.height():
-                # We must be sure to copy the data even when no one else does!
-                overlay = overlay.copy()
-            overlay = QtGui.QImage(overlay.data, shape[1], shape[0], QtGui.QImage.Format_RGBA8888)
-            if overlay.size() != self.label.size():
-                overlay = overlay.scaled(self.label.size())
+            overlay = QImage(overlay.data, shape[1], shape[0], QImage.Format_RGBA8888)
+        self.update_overlay_signal.emit(overlay)
 
+    def update_overlay(self, overlay):
         self.overlay = overlay
+        self.overlay_resized = None
+        self.update()
+
+    def recalculate_viewport(self):
+        size = self.label.size()
+        win_w = size.width()
+        win_h = size.height()
+
+        stream_map = self.picamera2.stream_map
+        camera_config = self.picamera2.camera_config
+        if not self.keep_ar or camera_config is None or camera_config['display'] is None:
+            return 0, 0, win_w, win_h
+
+        im_w, im_h = stream_map[camera_config['display']].configuration.size
+        if im_w * win_h > win_w * im_h:
+            im_win_w = win_w
+            im_win_h = win_w * im_h // im_w
+        else:
+            im_win_h = win_h
+            im_win_w = win_h * im_w // im_h
+        im_win_x = (win_w - im_win_w) // 2
+        im_win_y = (win_h - im_win_h) // 2
+        return (im_win_x, im_win_y, im_win_w, im_win_h)
+
+    def paintEvent(self, event):
+        # This all seems horribly expensive. Pull request welcome if you know a better way!
+        picam2 = self.picamera2
+        size = self.label.size()
+        win_w = size.width()
+        win_h = size.height()
+        im_win_x, im_win_y, im_win_w, im_win_h = self.recalculate_viewport()
+
+        # Check if the pil_img needs to be resized again if the window has changed.
+        if self.pil_img_resized:
+            if self.pil_img_resized.width != im_win_w or self.pil_img_resized.height != im_win_h:
+                self.pil_img_resized = None
+
+        # Remake the cached version that fits in the window.
+        if self.pil_img_resized is None and self.pil_img:
+            if self.pil_img.width == im_win_w and self.pil_img.height == im_win_h:
+                self.pil_img_resized = self.pil_img
+            else:
+                self.pil_img_resized = self.pil_img.resize((im_win_w, im_win_h))
+
+        # The cached resized overlay needs to be resized again if the window has changed.
+        if self.overlay_resized:
+            if self.overlay_resized.width() != im_win_w or self.overlay_resized.height() != im_win_h:
+                self.overlay_resized = None
+
+        # Remake the cached resized overlay.
+        if self.overlay and self.overlay_resized is None:
+            self.overlay_resized = self.overlay.scaled(im_win_w, im_win_h)
+
+        # Now render everything onto the label.
+        pixmap = QPixmap(win_w, win_h)
+        self.painter.begin(pixmap)
+        self.painter.fillRect(0, 0, win_w, win_h, QColor.fromRgb(*self.bg_colour))
+
+        if self.pil_img_resized:
+            self.painter.drawImage(im_win_x, im_win_y, ImageQt(self.pil_img_resized))
+
+        if self.overlay_resized:
+            self.painter.drawImage(im_win_x, im_win_y, self.overlay_resized)
+
+        self.painter.end()
+        self.label.setPixmap(pixmap)
+
+    def resizeEvent(self, event):
+        self.label.resize(self.width(), self.height())
+        self.update()
 
     @pyqtSlot()
     def handle_requests(self):
@@ -51,16 +122,10 @@ class QPicamera2(QWidget):
         if not request:
             return
 
+        self.pil_img = None
+        self.pil_img_resized = None
         if self.picamera2.display_stream_name is not None:
-            # This all seems horribly expensive. Pull request welcome if you know a better way!
-            size = self.label.size()
-            img = request.make_image(self.picamera2.display_stream_name, size.width(), size.height())
-            qim = ImageQt(img)
-            self.painter.begin(qim)
-            overlay = self.overlay
-            if overlay is not None:
-                self.painter.drawImage(0, 0, overlay)
-            self.painter.end()
-            pix = QtGui.QPixmap.fromImage(qim)
-            self.label.setPixmap(pix)
+            self.pil_img = request.make_image(self.picamera2.display_stream_name)
+
         request.release()
+        self.update()

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -1,13 +1,11 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import pyqtSlot, QSocketNotifier, Qt, pyqtSignal
-from PyQt5.QtGui import QColor, QPainter, QPixmap, QImage
-from PyQt5.QtWidgets import QWidget, QApplication, QLabel
-from PIL import Image
-from PIL.ImageQt import ImageQt
+from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal, QSocketNotifier, QSize, QRect, QRectF
+from PyQt5.QtWidgets import QGraphicsView, QGraphicsScene
+from PyQt5.QtGui import QBrush, QColor, QImage, QPixmap, QTransform
 import numpy as np
 
 
-class QPicamera2(QWidget):
+class QPicamera2(QGraphicsView):
     done_signal = pyqtSignal()
     update_overlay_signal = pyqtSignal(object)
 
@@ -15,106 +13,110 @@ class QPicamera2(QWidget):
         super().__init__(parent=parent)
         self.picamera2 = picam2
         picam2.have_event_loop = True
-        self.bg_colour = bg_colour
         self.keep_ar = keep_ar
-        self.pil_img = None
-        self.pil_img_resized = None
-        self.label = QLabel(self)
-        self.label.resize(width, height)
+        self.image_size = None
+        self.last_rect = QRect(0, 0, 0, 0)
+
+        self.size = QSize(width, height)
+        self.pixmap = None
         self.overlay = None
-        self.overlay_resized = None
-        self.painter = QPainter()
+        self.scene = QGraphicsScene()
+        self.setScene(self.scene)
+        self.setBackgroundBrush(QBrush(QColor(*bg_colour)))
+        self.resize(width, height)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.enabled = True
+
         self.update_overlay_signal.connect(self.update_overlay)
         self.camera_notifier = QSocketNotifier(self.picamera2.camera_manager.efd,
                                                QSocketNotifier.Read, self)
         self.camera_notifier.activated.connect(self.handle_requests)
 
     def cleanup(self):
-        del self.label
+        del self.scene
+        del self.overlay
         del self.camera_notifier
 
     def signal_done(self, picamera2):
         self.done_signal.emit()
 
+    def image_dimensions(self):
+        # The dimensions of the camera images we're displaying.
+        camera_config = self.picamera2.camera_config
+        if camera_config is not None and camera_config['display'] is not None:
+            # This works even before we receive any camera images.
+            size = self.picamera2.stream_map[camera_config['display']].configuration.size
+        elif self.image_size is not None:
+            # If the camera is unconfigured, stick with the last size (if available).
+            size = self.image_size
+        else:
+            # Otherwise pretend the image fills everything.
+            rect = self.viewport().rect()
+            size = rect.width(), rect.height()
+        self.image_size = size
+        return size
+
     def set_overlay(self, overlay):
+        camera_config = self.picamera2.camera_config
+        if camera_config is None:
+            raise RuntimeError("Camera must be configured before using set_overlay")
+
+        new_pixmap = None
         if overlay is not None:
             overlay = np.copy(overlay, order='C')
             shape = overlay.shape
-            overlay = QImage(overlay.data, shape[1], shape[0], QImage.Format_RGBA8888)
-        self.update_overlay_signal.emit(overlay)
+            qim = QImage(overlay.data, shape[1], shape[0], QImage.Format_RGBA8888)
+            new_pixmap = QPixmap(qim)
+            # No scaling here - we leave it to fitInView to set that up.
+        self.update_overlay_signal.emit(new_pixmap)
 
-    def update_overlay(self, overlay):
-        self.overlay = overlay
-        self.overlay_resized = None
-        self.update()
-
-    def recalculate_viewport(self):
-        size = self.label.size()
-        win_w = size.width()
-        win_h = size.height()
-
-        stream_map = self.picamera2.stream_map
-        camera_config = self.picamera2.camera_config
-        if not self.keep_ar or camera_config is None or camera_config['display'] is None:
-            return 0, 0, win_w, win_h
-
-        im_w, im_h = stream_map[camera_config['display']].configuration.size
-        if im_w * win_h > win_w * im_h:
-            im_win_w = win_w
-            im_win_h = win_w * im_h // im_w
+    @pyqtSlot(object)
+    def update_overlay(self, pix):
+        if pix is None:
+            # Delete overlay if present
+            if self.overlay is not None:
+                self.scene.removeItem(self.overlay)
+                self.overlay = None
+                return
+        elif self.overlay is None:
+            # Need to add the overlay to the scene
+            self.overlay = self.scene.addPixmap(pix)
+            self.overlay.setZValue(100)
         else:
-            im_win_h = win_h
-            im_win_w = win_h * im_w // im_h
-        im_win_x = (win_w - im_win_w) // 2
-        im_win_y = (win_h - im_win_h) // 2
-        return (im_win_x, im_win_y, im_win_w, im_win_h)
+            # Just update it
+            self.overlay.setPixmap(pix)
+        self.fitInView()
 
-    def paintEvent(self, event):
-        # This all seems horribly expensive. Pull request welcome if you know a better way!
-        picam2 = self.picamera2
-        size = self.label.size()
-        win_w = size.width()
-        win_h = size.height()
-        im_win_x, im_win_y, im_win_w, im_win_h = self.recalculate_viewport()
+    @pyqtSlot(bool)
+    def set_enabled(self, enabled):
+        self.enabled = enabled
 
-        # Check if the pil_img needs to be resized again if the window has changed.
-        if self.pil_img_resized:
-            if self.pil_img_resized.width != im_win_w or self.pil_img_resized.height != im_win_h:
-                self.pil_img_resized = None
+    def fitInView(self):
+        # Reimplemented fitInView to remove fixed border
+        image_w, image_h = self.image_dimensions()
+        rect = QRectF(0, 0, image_w, image_h)
+        self.setSceneRect(rect)
+        # I get one column of background peeping through on the right without this:
+        viewrect = self.viewport().rect().adjusted(0, 0, 1, 1)
+        self.resetTransform()
+        factor_x = viewrect.width() / image_w
+        factor_y = viewrect.height() / image_h
+        if self.keep_ar:
+            factor_x = min(factor_x, factor_y)
+            factor_y = factor_x
+        self.scale(factor_x, factor_y)
 
-        # Remake the cached version that fits in the window.
-        if self.pil_img_resized is None and self.pil_img:
-            if self.pil_img.width == im_win_w and self.pil_img.height == im_win_h:
-                self.pil_img_resized = self.pil_img
-            else:
-                self.pil_img_resized = self.pil_img.resize((im_win_w, im_win_h))
-
-        # The cached resized overlay needs to be resized again if the window has changed.
-        if self.overlay_resized:
-            if self.overlay_resized.width() != im_win_w or self.overlay_resized.height() != im_win_h:
-                self.overlay_resized = None
-
-        # Remake the cached resized overlay.
-        if self.overlay and self.overlay_resized is None:
-            self.overlay_resized = self.overlay.scaled(im_win_w, im_win_h)
-
-        # Now render everything onto the label.
-        pixmap = QPixmap(win_w, win_h)
-        self.painter.begin(pixmap)
-        self.painter.fillRect(0, 0, win_w, win_h, QColor.fromRgb(*self.bg_colour))
-
-        if self.pil_img_resized:
-            self.painter.drawImage(im_win_x, im_win_y, ImageQt(self.pil_img_resized))
-
-        if self.overlay_resized:
-            self.painter.drawImage(im_win_x, im_win_y, self.overlay_resized)
-
-        self.painter.end()
-        self.label.setPixmap(pixmap)
+        # This scales the overlay to be on top of the camera image.
+        if self.overlay:
+            rect = self.overlay.boundingRect()
+            self.overlay.resetTransform()
+            factor_x = image_w / rect.width()
+            factor_y = image_h / rect.height()
+            self.overlay.setTransform(QTransform.fromScale(factor_x, factor_y), True)
 
     def resizeEvent(self, event):
-        self.label.resize(self.width(), self.height())
-        self.update()
+        self.fitInView()
 
     @pyqtSlot()
     def handle_requests(self):
@@ -122,10 +124,21 @@ class QPicamera2(QWidget):
         if not request:
             return
 
-        self.pil_img = None
-        self.pil_img_resized = None
-        if self.picamera2.display_stream_name is not None:
-            self.pil_img = request.make_image(self.picamera2.display_stream_name)
-
+        if self.enabled and self.picamera2.display_stream_name is not None:
+            img = request.make_array(self.picamera2.display_stream_name)
+            img = np.ascontiguousarray(img[..., :3])
+            shape = img.shape
+            qim = QImage(img.data, shape[1], shape[0], QImage.Format_RGB888)
+            pix = QPixmap(qim)
+            # Add the pixmap to the scene if there wasn't one, or replace it if the images have
+            # changed size.
+            if self.pixmap is None or pix.rect() != self.last_rect:
+                if self.pixmap:
+                    self.scene.removeItem(self.pixmap)
+                self.last_rect = pix.rect()
+                self.pixmap = self.scene.addPixmap(pix)
+                self.fitInView()
+            else:
+                # Update pixmap
+                self.pixmap.setPixmap(pix)
         request.release()
-        self.update()

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -33,7 +33,7 @@ def capture_done():
     button.setEnabled(True)
 
 
-qpicamera2 = QGlPicamera2(picam2, width=800, height=600)
+qpicamera2 = QGlPicamera2(picam2, width=800, height=600, keep_ar=False)
 button = QPushButton("Click to capture JPEG")
 label = QLabel()
 window = QWidget()


### PR DESCRIPTION
These commits involve quite a lot of rework to the various preview window implementations. So there are quite a lot of commits here, my apologies for that. There are

- 4 commits related to the QGlPicamera2 widget, the last of which just amends a couple of tests to work better;
- 3 commits for the DrmPreview;
- 1 commit for the QPicamera2 and 1 more to add another example;
- And then 1 final commit that simply updates the changelog.

In all cases, the commits make the previews handle aspect ratio correctly. Image aspect ratios are now preserved by default (though that can be over-ridden). Also the treatment of overlays is improved in all cases so that they get redrawn even if the camera is not delivering images. Finally, the Q versions also allow the background colour to be set (as this may be visible if the widgets and camera images do not share the same aspect ratio).