### PR TITLE
Make still_configuration default to having no display or encode stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 
+* The still_configuration defaults now specify the default display and encode streams as none. The resolutions are often so large that the images can be problematic and there are often better alternatives (e.g. specifying a lores stream and displaying that instead).
 * The preview window implementations are changed to preserve image aspect ratios which they did not previously. The Qt variants also respect resize events.
 
 ## 0.2.1 Alpha Release

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -279,7 +279,7 @@ class Picamera2:
         self.add_display_and_encode(config, display, encode)
         return config
 
-    def still_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=1, controls={}, display="main", encode="main") -> dict:
+    def still_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=1, controls={}, display=None, encode=None) -> dict:
         "Make a configuration suitable for still image capture. Default to 2 buffers, as the Gl preview would need them."
         if self.camera is None:
             raise RuntimeError("Camera not opened")


### PR DESCRIPTION
Typically the resolutions are so large that trying to display or
encode these streams can be problematic. You can override the defaults
to obtain the previous behaviour, but in general we would recommend:

* If you want to encode a stream, start from the video_configuration,
  and increase the size if you need to.

* If you want to display the still stream, you'll often do better to
  specify a lores stream and set that as the "display" stream. e.g.
  picam2.still_configuration(lores={"size": (800, 600)}, display="lores")

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>