### PR TITLE
Add YUV420 support to the QPicamera2 widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* The QPicamera2 widget will now display YUV420 images if the cv2 (OpenCV) module is installed.
 * Methods that allow still captures to be saved to files have been updated to accept file-like objects, such as BytesIO.
 * NOGUI=1 environmental variable to install without GUI dependencies
 * The Picamera2's request_callback has been changed to post_callback. A new pre_callback has been added which runs before images copied for applications.


### PR DESCRIPTION
This is the non-OpenGL accelerated version which previously could not
display YUV420 format images. It can do so now through the use of
OpenCV which provides a much faster YUV to RGB conversion function
than we can write easily using numpy. (But be under no illusions that
it still costs quite a bit of CPU!)

If OpenCV is not available, an error is only thrown if you try to
display a YUV420 image, everything else will work as before.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>