### PR TITLE
API changes for the Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@
 
 ### Added
 
+* A very trivial Metadata class is provided that can be used to wrap the metadata dictionaries, for those that prefer this style.
+* A Controls class is provided which gives an object-like view to control lists. The class is able to check that the control names are valid.
+* Configuration structures are provided so that the Picamera2 object can be configured using the "object" style. Three such instances are embedded in the Picamera2 object, namely preview_configuration, still_configuration and video_configuration.
+
 ### Changed
+
+* The start_recording() method accepts an optional configuration.
+* The start_preview() method accepts True as an indication to try and autodetect the correct type of preview window. Note that there will be situations where it guesses incorrectly.
+* The start() method can optionally be given config and show_preview parameters which will configure the camera and start the preview (if it isn't running already).
+* Streams no longer have their widths optimally aligned by default. A separate align_configuration() method can be called to enforce this.
+* The preview_configuration(), still_configuration() and video_configuration() methods (xxx_configuration) are renamed to create_xxx_configuration().
 
 ## 0.2.2 Alpha Release 2
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ The imaging hardware on the Pi is capable of supplying up to 3 image streams to 
 
 After opening the camera, *Picamera2* must be configured with the `Picamera2.configure` method. It provides three methods for generating suitable configurations:
 
-- `Picamera2.preview_configuration` generates configurations normally suitable for camera preview.
-- `Picamera2.still_configuration` generates configurations normally suitable for still image capture.
-- `Picamera2.video_configuration` generates configurations for video recording.
+- `Picamera2.create_preview_configuration` generates configurations normally suitable for camera preview.
+- `Picamera2.create_still_configuration` generates configurations normally suitable for still image capture.
+- `Picamera2.create_video_configuration` generates configurations for video recording.
 
 In all cases, these functions can generate configurations with no user arguments at all. Otherwise the user may supply the following parameters:
 
@@ -148,38 +148,38 @@ Examples:
 
 Configure a default resolution preview.
 ```
-config = picam2.preview_configuration()
+config = picam2.create_preview_configuration()
 picam2.configure(config)
 ```
 
 Configure for a full resolution capture.
 ```
-config = picam2.still_configuration()
+config = picam2.create_still_configuration()
 picam2.configure(config)
 ```
 
 Here we configure both a VGA preview (*main*) stream, and a QVGA low resolution (*lores*) stream.
 ```
-config = picam2.preview_configuration(main={"size": (640, 480)},
+config = picam2.create_preview_configuration(main={"size": (640, 480)},
                                       lores={"size": (320, 240), "format": "YUV420"})
 picam2.configure(config)
 ```
 
 Ask for an additional raw stream at the sensor resolution. This will force the camera to run at the maximum resolution, probably at a reduced framerate. Without the size parameter (just `raw={}`) the raw frame would be the one that *libcamera* would naturally choose for the resolution of the main stream (probably much smaller).
 ```
-config = picam2.preview_configuration(raw={"size": picam2.sensor_resolution})
+config = picam2.create_preview_configuration(raw={"size": picam2.sensor_resolution})
 picam2.configure(config)
 ```
 
 Rotate all the images by 180 degrees.
 ```
-config = picam2.preview_configuration(transform=libcamera.Transform(hflip=1, vflip=1))
+config = picam2.create_preview_configuration(transform=libcamera.Transform(hflip=1, vflip=1))
 picam2.configure(config)
 ```
 
 Still image capture normally configures only a single buffer, as this is all you need. But if you're doing some form of burst capture, increasing the buffer count may enable the application to receive images more quickly.
 ```
-config = picam2.still_configuration(buffer_count=3)
+config = picam2.create_still_configuration(buffer_count=3)
 picam2.configure(config)
 ```
 
@@ -204,7 +204,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-config = picam2.preview_configuration()
+config = picam2.create_preview_configuration()
 picam2.configure(config)
 
 picam2.start()
@@ -241,7 +241,7 @@ from picamera2 import Picamera2, Preview
 import numpy as np
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration({"size": (640, 480)}))
+picam2.configure(picam2.create_preview_configuration({"size": (640, 480)}))
 picam2.start_preview(Preview.QTGL)
 overlay = np.zeros((200, 200, 4), dtype=np.uint8)
 overlay[:100, 100:] = (255, 0, 0, 64)  # red
@@ -297,13 +297,13 @@ request.release()
 
 When switching to a full resolution capture, it's common to re-start the camera in preview mode afterwards. When capturing a whole request, however, you can't re-start the camera until you're finished with that request:
 ```
-capture_config = picam2.still_configuration()
+capture_config = picam2.create_still_configuration()
 request = picam2.switch_mode_capture_request_and_stop(capture_config)
 # The camera is stopped but we can use the request. Then return the request:
 request.release()
 # And the camera could be re-configured and restarted.
-preview_config = picam2.preview_configuration()
-picam2.configure(preview_configuration)
+preview_config = picam2.create_preview_configuration()
+picam2.configure(preview_config)
 picam2.start()
 ```
 
@@ -311,7 +311,7 @@ picam2.start()
 
 Picamera2 supports saving DNG files through the _PiDNG_ library. When capturing DNGs, you will need to specify that you want a raw stream. For example, if the camera is running a normal preview, the following snippet would switch to full resolution mode (with a raw stream) and capture a DNG file.
 ```
-capture_config = picam2.still_configuration(raw={})
+capture_config = picam2.create_still_configuration(raw={})
 picam2.switch_mode_and_capture_file(capture_config, "full-res.dng", name="raw")
 ```
 
@@ -364,7 +364,7 @@ There is a second version of this [app_capture2.py](examples/app_capture2.py) th
 
 This application starts a preview window and then performs a full resolution JPEG capture. The preview normally uses one of the camera's faster readout modes, so we have to pick a separate *capture* mode, and *switch* to it, for the final capture.
 
-The `Picamera2.preview_configuration` method is best for selecting camera modes suitable for previewing, and `Picamera2.still_configuration` is best for selecting high resolution still capture modes.
+The `Picamera2.create_preview_configuration` method is best for selecting camera modes suitable for previewing, and `Picamera2.create_still_configuration` is best for selecting high resolution still capture modes.
 
 ### [capture_image_full_res.py](examples/capture_image_full_res.py)
 

--- a/examples/app_capture.py
+++ b/examples/app_capture.py
@@ -13,14 +13,14 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 
 app = QApplication([])
 
 
 def on_button_clicked():
     if not picam2.async_operation_in_progress:
-        cfg = picam2.still_configuration()
+        cfg = picam2.create_still_configuration()
         picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False, signal_function=None)
     else:
         print("Busy!")

--- a/examples/app_capture2.py
+++ b/examples/app_capture2.py
@@ -17,14 +17,14 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 
 app = QApplication([])
 
 
 def on_button_clicked():
     button.setEnabled(False)
-    cfg = picam2.still_configuration()
+    cfg = picam2.create_still_configuration()
     picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False, signal_function=qpicamera2.signal_done)
 
 

--- a/examples/app_capture_overlay.py
+++ b/examples/app_capture_overlay.py
@@ -19,13 +19,13 @@ def cleanup():
 
 picam2 = Picamera2()
 picam2.post_callback = request_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 app = QApplication([])
 
 
 def on_button_clicked():
     if not picam2.async_operation_in_progress:
-        cfg = picam2.still_configuration()
+        cfg = picam2.create_still_configuration()
         picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False,
                                             signal_function=None)
     else:

--- a/examples/app_capture_request.py
+++ b/examples/app_capture_request.py
@@ -17,7 +17,7 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 
 app = QApplication([])
 

--- a/examples/app_recording.py
+++ b/examples/app_recording.py
@@ -15,7 +15,7 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.video_configuration(main={"size": (1280, 720)}))
+picam2.configure(picam2.create_video_configuration(main={"size": (1280, 720)}))
 
 app = QApplication([])
 

--- a/examples/audio_video_capture.py
+++ b/examples/audio_video_capture.py
@@ -6,7 +6,7 @@ from picamera2.outputs import FfmpegOutput
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration()
+video_config = picam2.create_video_configuration()
 picam2.configure(video_config)
 
 encoder = H264Encoder(10000000)

--- a/examples/capture_circular.py
+++ b/examples/capture_circular.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2
 
 lsize = (320, 240)
 picam2 = Picamera2()
-video_config = picam2.video_configuration(main={"size": (1280, 720), "format": "RGB888"},
+video_config = picam2.create_video_configuration(main={"size": (1280, 720), "format": "RGB888"},
                                           lores={"size": lsize, "format": "YUV420"})
 picam2.configure(video_config)
 picam2.start_preview()

--- a/examples/capture_circular_stream.py
+++ b/examples/capture_circular_stream.py
@@ -10,7 +10,7 @@ from picamera2.outputs import CircularOutput, FileOutput
 
 lsize = (320, 240)
 picam2 = Picamera2()
-video_config = picam2.video_configuration(main={"size": (1280, 720), "format": "RGB888"},
+video_config = picam2.create_video_configuration(main={"size": (1280, 720), "format": "RGB888"},
                                           lores={"size": lsize, "format": "YUV420"})
 picam2.configure(video_config)
 picam2.start_preview()

--- a/examples/capture_dng.py
+++ b/examples/capture_dng.py
@@ -8,8 +8,8 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
-capture_config = picam2.still_configuration(raw={})
+preview_config = picam2.create_preview_configuration()
+capture_config = picam2.create_still_configuration(raw={})
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/capture_dng_and_jpeg.py
+++ b/examples/capture_dng_and_jpeg.py
@@ -8,8 +8,8 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
-capture_config = picam2.still_configuration(raw={}, display=None)
+preview_config = picam2.create_preview_configuration()
+capture_config = picam2.create_still_configuration(raw={}, display=None)
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/capture_full_res.py
+++ b/examples/capture_full_res.py
@@ -8,8 +8,8 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
-capture_config = picam2.still_configuration()
+preview_config = picam2.create_preview_configuration()
+capture_config = picam2.create_still_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/capture_headless.py
+++ b/examples/capture_headless.py
@@ -3,7 +3,7 @@
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-config = picam2.still_configuration()
+config = picam2.create_still_configuration()
 picam2.configure(config)
 
 picam2.start()

--- a/examples/capture_image_full_res.py
+++ b/examples/capture_image_full_res.py
@@ -7,8 +7,8 @@ import time
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
-preview_config = picam2.preview_configuration()
-capture_config = picam2.still_configuration()
+preview_config = picam2.create_preview_configuration()
+capture_config = picam2.create_still_configuration()
 
 picam2.configure(preview_config)
 picam2.start()

--- a/examples/capture_jpeg.py
+++ b/examples/capture_jpeg.py
@@ -8,7 +8,7 @@ import time
 
 picam2 = Picamera2()
 
-preview_config = picam2.preview_configuration(main={"size": (800, 600)})
+preview_config = picam2.create_preview_configuration(main={"size": (800, 600)})
 picam2.configure(preview_config)
 
 picam2.start_preview(Preview.QTGL)

--- a/examples/capture_mjpeg.py
+++ b/examples/capture_mjpeg.py
@@ -6,7 +6,7 @@ from picamera2 import Picamera2
 
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration(main={"size": (1920, 1080)})
+video_config = picam2.create_video_configuration(main={"size": (1920, 1080)})
 picam2.configure(video_config)
 
 picam2.start_preview()

--- a/examples/capture_mjpeg_v4l2.py
+++ b/examples/capture_mjpeg_v4l2.py
@@ -5,7 +5,7 @@ from picamera2.encoders import MJPEGEncoder
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration()
+video_config = picam2.create_video_configuration()
 picam2.configure(video_config)
 
 encoder = MJPEGEncoder(10000000)

--- a/examples/capture_motion.py
+++ b/examples/capture_motion.py
@@ -11,7 +11,7 @@ from picamera2 import Picamera2
 
 lsize = (320, 240)
 picam2 = Picamera2()
-video_config = picam2.video_configuration(main={"size": (1280, 720), "format": "RGB888"}, 
+video_config = picam2.create_video_configuration(main={"size": (1280, 720), "format": "RGB888"},
                                           lores={"size": lsize, "format": "YUV420"})
 picam2.configure(video_config)
 encoder = H264Encoder(1000000)

--- a/examples/capture_png.py
+++ b/examples/capture_png.py
@@ -8,7 +8,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration(main={"size": (800, 600)})
+preview_config = picam2.create_preview_configuration(main={"size": (800, 600)})
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/capture_stream.py
+++ b/examples/capture_stream.py
@@ -8,7 +8,7 @@ from picamera2.outputs import FileOutput
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration({"size": (1280, 720)})
+video_config = picam2.create_video_configuration({"size": (1280, 720)})
 picam2.configure(video_config)
 encoder = H264Encoder(1000000)
 

--- a/examples/capture_stream_udp.py
+++ b/examples/capture_stream_udp.py
@@ -8,7 +8,7 @@ from picamera2.outputs import FileOutput
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration({"size": (1280, 720)})
+video_config = picam2.create_video_configuration({"size": (1280, 720)})
 picam2.configure(video_config)
 encoder = H264Encoder(1000000)
 

--- a/examples/capture_to_buffer.py
+++ b/examples/capture_to_buffer.py
@@ -5,8 +5,8 @@ import io
 import time
 
 picam2 = Picamera2()
-capture_config = picam2.still_configuration()
-picam2.configure(picam2.preview_configuration())
+capture_config = picam2.create_still_configuration()
+picam2.configure(picam2.create_preview_configuration())
 picam2.start()
 
 time.sleep(1)

--- a/examples/capture_video.py
+++ b/examples/capture_video.py
@@ -5,7 +5,7 @@ from picamera2.encoders import H264Encoder
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration()
+video_config = picam2.create_video_configuration()
 picam2.configure(video_config)
 
 encoder = H264Encoder(10000000)

--- a/examples/controls.py
+++ b/examples/controls.py
@@ -9,7 +9,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/controls_2.py
+++ b/examples/controls_2.py
@@ -8,7 +8,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/controls_3.py
+++ b/examples/controls_3.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+
+# Example of setting controls using the "direct" attribute method.
+
+from picamera2 import Picamera2, Preview
+import time
+
+from picamera2.controls import Controls
+
+picam2 = Picamera2()
+picam2.start_preview(Preview.QTGL)
+
+preview_config = picam2.preview_configuration()
+picam2.configure(preview_config)
+
+picam2.start()
+time.sleep(1)
+
+with picam2.controls as ctrl:
+    ctrl.AnalogueGain = 6.0
+    ctrl.ExposureTime = 60000
+
+time.sleep(2)
+
+ctrls = Controls(picam2)
+ctrls.AnalogueGain = 1.0
+ctrls.ExposureTime = 10000
+picam2.set_controls(ctrls)
+
+time.sleep(2)

--- a/examples/exposure_fixed.py
+++ b/examples/exposure_fixed.py
@@ -8,7 +8,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 controls = {"ExposureTime": 10000, "AnalogueGain": 1.0}
-preview_config = picam2.preview_configuration(controls=controls)
+preview_config = picam2.create_preview_configuration(controls=controls)
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/metadata.py
+++ b/examples/metadata.py
@@ -8,7 +8,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/metadata_with_image.py
+++ b/examples/metadata_with_image.py
@@ -9,7 +9,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/mjpeg_server.py
+++ b/examples/mjpeg_server.py
@@ -83,7 +83,7 @@ class StreamingServer(socketserver.ThreadingMixIn, server.HTTPServer):
 
 
 picam2 = Picamera2()
-picam2.configure(picam2.video_configuration(main={"size": (640, 480)}))
+picam2.configure(picam2.create_video_configuration(main={"size": (640, 480)}))
 output = StreamingOutput()
 picam2.start_recording(JpegEncoder(), FileOutput(output))
 

--- a/examples/mp4_capture.py
+++ b/examples/mp4_capture.py
@@ -6,7 +6,7 @@ from picamera2.outputs import FfmpegOutput
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration()
+video_config = picam2.create_video_configuration()
 picam2.configure(video_config)
 
 encoder = H264Encoder(10000000)

--- a/examples/ocr.py
+++ b/examples/ocr.py
@@ -10,7 +10,7 @@ import cv2
 from pprint import pprint
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration({"size": (1024, 768)}))
+picam2.configure(picam2.create_preview_configuration({"size": (1024, 768)}))
 picam2.start_preview(Preview.QTGL)
 picam2.start()
 

--- a/examples/opencv_face_detect.py
+++ b/examples/opencv_face_detect.py
@@ -10,7 +10,7 @@ face_detector = cv2.CascadeClassifier("/usr/share/opencv4/haarcascades/haarcasca
 cv2.startWindowThread()
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration(main={"format": 'XRGB8888', "size": (640, 480)}))
+picam2.configure(picam2.create_preview_configuration(main={"format": 'XRGB8888', "size": (640, 480)}))
 picam2.start()
 
 while True:

--- a/examples/opencv_face_detect_2.py
+++ b/examples/opencv_face_detect_2.py
@@ -24,7 +24,7 @@ def draw_faces(request):
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
-config = picam2.preview_configuration(main={"size": (640, 480)},
+config = picam2.create_preview_configuration(main={"size": (640, 480)},
                                       lores={"size": (320, 240), "format": "YUV420"})
 picam2.configure(config)
 

--- a/examples/opencv_face_detect_3.py
+++ b/examples/opencv_face_detect_3.py
@@ -22,7 +22,7 @@ def draw_faces(request):
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
-config = picam2.preview_configuration(main={"size": (640, 480)},
+config = picam2.create_preview_configuration(main={"size": (640, 480)},
                                       lores={"size": (320, 240), "format": "YUV420"})
 picam2.configure(config)
 

--- a/examples/opencv_mertens_merge.py
+++ b/examples/opencv_mertens_merge.py
@@ -12,7 +12,7 @@ from picamera2 import Picamera2
 RATIO = 3.0
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start()
 
 # Run for a second to get a reasonable "middle" exposure level.
@@ -22,7 +22,7 @@ exposure_normal = metadata["ExposureTime"]
 gain = metadata["AnalogueGain"] * metadata["DigitalGain"]
 picam2.stop()
 controls = {"ExposureTime": exposure_normal, "AnalogueGain": gain}
-capture_config = picam2.preview_configuration(main={"size": (1024, 768),
+capture_config = picam2.create_preview_configuration(main={"size": (1024, 768),
                                                     "format": "RGB888"},
                                               controls=controls)
 picam2.configure(capture_config)

--- a/examples/overlay_drm.py
+++ b/examples/overlay_drm.py
@@ -5,7 +5,7 @@ import numpy as np
 import time
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(Preview.DRM)
 picam2.start()
 time.sleep(1)

--- a/examples/overlay_gl.py
+++ b/examples/overlay_gl.py
@@ -5,7 +5,7 @@ import numpy as np
 import time
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(Preview.QTGL)
 picam2.start()
 time.sleep(1)

--- a/examples/overlay_null.py
+++ b/examples/overlay_null.py
@@ -7,7 +7,7 @@ import numpy as np
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start()
 time.sleep(1)
 

--- a/examples/overlay_qt.py
+++ b/examples/overlay_qt.py
@@ -5,7 +5,7 @@ import numpy as np
 import time
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(Preview.QT)
 picam2.start()
 time.sleep(1)

--- a/examples/preview.py
+++ b/examples/preview.py
@@ -9,7 +9,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/preview_drm.py
+++ b/examples/preview_drm.py
@@ -8,7 +8,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.DRM, x=100, y=100, width=640, height=480)
 
-preview_config = picam2.preview_configuration({"size": (640, 360)})
+preview_config = picam2.create_preview_configuration({"size": (640, 360)})
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/preview_null.py
+++ b/examples/preview_null.py
@@ -4,7 +4,7 @@ import time
 from picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
-config = picam2.preview_configuration()
+config = picam2.create_preview_configuration()
 picam2.configure(config)
 
 # In fact, picam2.start() would do this anyway for us:

--- a/examples/preview_x_forwarding.py
+++ b/examples/preview_x_forwarding.py
@@ -9,7 +9,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QT)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/raw.py
+++ b/examples/raw.py
@@ -8,7 +8,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration(raw={"size": picam2.sensor_resolution})
+preview_config = picam2.create_preview_configuration(raw={"size": picam2.sensor_resolution})
 print(preview_config)
 picam2.configure(preview_config)
 

--- a/examples/rotation.py
+++ b/examples/rotation.py
@@ -10,7 +10,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 preview_config["transform"] = libcamera.Transform(hflip=1, vflip=1)
 picam2.configure(preview_config)
 

--- a/examples/still_capture_with_config.py
+++ b/examples/still_capture_with_config.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+# Use the configuration structure method to do a full res capture.
+
+from picamera2 import Picamera2
+import time
+
+picam2 = Picamera2()
+
+# We don't really need to change anyhting, but let's mess around just as a test.
+picam2.preview_configuration.size = (800, 600)
+picam2.preview_configuration.format = "YUV420"
+picam2.still_configuration.size = (1600, 1200)
+picam2.still_configuration.enable_raw()
+picam2.still_configuration.raw.size = picam2.sensor_resolution
+
+picam2.start("preview", show_preview=True)
+time.sleep(2)
+
+picam2.switch_mode_and_capture_file("still", "test_full.jpg")

--- a/examples/still_during_video.py
+++ b/examples/still_during_video.py
@@ -11,7 +11,7 @@ picam2 = Picamera2()
 half_resolution = [dim // 2 for dim in picam2.sensor_resolution]
 main_stream = {"size": half_resolution}
 lores_stream = {"size": (640, 480)}
-video_config = picam2.video_configuration(main_stream, lores_stream, encode="lores")
+video_config = picam2.create_video_configuration(main_stream, lores_stream, encode="lores")
 picam2.configure(video_config)
 
 encoder = H264Encoder(10000000)

--- a/examples/switch_mode.py
+++ b/examples/switch_mode.py
@@ -8,13 +8,13 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()
 time.sleep(2)
 
-other_config = picam2.preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
+other_config = picam2.create_preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
 
 picam2.switch_mode(other_config)
 time.sleep(2)

--- a/examples/switch_mode_2.py
+++ b/examples/switch_mode_2.py
@@ -8,14 +8,14 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()
 time.sleep(2)
 picam2.stop()
 
-other_config = picam2.preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
+other_config = picam2.create_preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
 picam2.configure(other_config)
 
 picam2.start()

--- a/examples/tensorflow/real_time.py
+++ b/examples/tensorflow/real_time.py
@@ -132,7 +132,7 @@ def main():
 
     picam2 = Picamera2()
     picam2.start_preview(Preview.QTGL)
-    config = picam2.preview_configuration(main={"size": normalSize},
+    config = picam2.create_preview_configuration(main={"size": normalSize},
                                           lores={"size": lowresSize, "format": "YUV420"})
     picam2.configure(config)
 

--- a/examples/tensorflow/real_time_with_labels.py
+++ b/examples/tensorflow/real_time_with_labels.py
@@ -138,7 +138,7 @@ def main():
 
     picam2 = Picamera2()
     picam2.start_preview(Preview.QTGL)
-    config = picam2.preview_configuration(main={"size": normalSize},
+    config = picam2.create_preview_configuration(main={"size": normalSize},
                                           lores={"size": lowresSize, "format": "YUV420"})
     picam2.configure(config)
 

--- a/examples/timestamped_video.py
+++ b/examples/timestamped_video.py
@@ -6,7 +6,7 @@ import cv2
 import time
 
 picam2 = Picamera2()
-picam2.configure(picam2.video_configuration())
+picam2.configure(picam2.create_video_configuration())
 
 colour = (0, 255, 0)
 origin = (0, 30)

--- a/examples/tuning_file.py
+++ b/examples/tuning_file.py
@@ -11,7 +11,7 @@ tuning = Picamera2.load_tuning_file("imx477.json")
 tuning["rpi.agc"]["exposure_modes"]["normal"] = {"shutter": [100, 66666], "gain": [1.0, 8.0]}
 
 picam2 = Picamera2(tuning=tuning)
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(Preview.QTGL)
 picam2.start()
 time.sleep(2)

--- a/examples/video_with_config.py
+++ b/examples/video_with_config.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+
+# Use the configuration structure method to do a full res capture.
+
+from picamera2 import Picamera2
+from picamera2.encoders import H264Encoder
+import time
+
+picam2 = Picamera2()
+
+# We don't really need to change anyhting, but let's mess around just as a test.
+picam2.video_configuration.size = (800, 480)
+picam2.video_configuration.format = "YUV420"
+encoder = H264Encoder(bitrate=1000000)
+
+picam2.start_recording(encoder, "test.h264", config="video")
+time.sleep(5)
+picam2.stop_recording()

--- a/examples/window_offset.py
+++ b/examples/window_offset.py
@@ -8,7 +8,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL, x=100, y=200)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/yuv_to_rgb.py
+++ b/examples/yuv_to_rgb.py
@@ -6,7 +6,7 @@ import cv2
 cv2.startWindowThread()
 
 picam2 = Picamera2()
-config = picam2.preview_configuration(lores={"size": (640, 480)})
+config = picam2.create_preview_configuration(lores={"size": (640, 480)})
 picam2.configure(config)
 picam2.start()
 

--- a/examples/zoom.py
+++ b/examples/zoom.py
@@ -8,7 +8,7 @@ import time
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/picamera2/__init__.py
+++ b/picamera2/__init__.py
@@ -2,3 +2,4 @@ from .picamera2 import Picamera2, Preview
 from .request import CompletedRequest, MappedArray
 from .converters import YUV420_to_RGB
 from .configuration import CameraConfiguration, StreamConfiguration
+from .controls import Controls

--- a/picamera2/__init__.py
+++ b/picamera2/__init__.py
@@ -1,3 +1,4 @@
 from .picamera2 import Picamera2, Preview
 from .request import CompletedRequest, MappedArray
 from .converters import YUV420_to_RGB
+from .configuration import CameraConfiguration, StreamConfiguration

--- a/picamera2/__init__.py
+++ b/picamera2/__init__.py
@@ -3,3 +3,4 @@ from .request import CompletedRequest, MappedArray
 from .converters import YUV420_to_RGB
 from .configuration import CameraConfiguration, StreamConfiguration
 from .controls import Controls
+from .metadata import Metadata

--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -1,0 +1,86 @@
+
+class Configuration:
+    """
+    A small wrapper class that can be used to turn our configuration dicts into real objects.
+    The constructor can make an empty object, or initialise from a dict. There is also the
+    make_dict() method which turns the object back into a dict.
+
+    Derived classes should define:
+
+    _ALLOWED_FIELDS: these are the only attributes that may be set, anything else will raise
+        an error. The idea is to help prevent typos.
+
+    _FIELD_CLASS_MAP: this allows you to turn a dict that we are given as a value (for some
+        field) into a Configuration object. For example if someone is setting a dict into a
+        field of a CameraConfiguration, you might want it to turn into a StreamConfiguration.
+
+        One of these fields can be set by doing (for example) camera_config.lores = {}, which
+        would be turned into a StreamConfiguration. Or for those averse to dicts, we allow
+        camera_config.enable_lores() instead.
+
+    _FORWARD_FIELDS: allows certain attribute names to be forwarded to another contained
+        object. For example, if someone wants to set CameraConfiguration.size they probably
+        mean to set CameraConfiguration.main.size. So it's a kind of helpful shorthand.
+    """
+    def __init__(self, d={}):
+        if isinstance(d, Configuration):
+            d = d.make_dict()
+        for k in self._ALLOWED_FIELDS:
+            self.__setattr__(k, None)
+        for k, v in d.items():
+            self.__setattr__(k, v)
+
+    def __setattr__(self, name, value):
+        if name in self._FORWARD_FIELDS:
+            target = self._FORWARD_FIELDS[name]
+            self.__getattribute__(target).__setattr__(name, value)
+        elif name in self._ALLOWED_FIELDS:
+            if name in self._FIELD_CLASS_MAP and isinstance(value, dict):
+                value = self._FIELD_CLASS_MAP[name](value)
+            super().__setattr__(name, value)
+        else:
+            raise RuntimeError(f"Invalid field '{name}'")
+
+    def __getattribute__(self, name):
+        prefix = "enable_"
+        if name.startswith(prefix) and len(name) > len(prefix):
+            field = name[len(prefix):]
+
+            def func(onoff=True):
+                if onoff:
+                    self.__setattr__(field, {})
+                else:
+                    delattr(self, field)
+            return func
+
+        else:
+            return super().__getattribute__(name)
+
+    def __repr__(self):
+        return type(self).__name__ + "(" + repr(self.make_dict()) + ")"
+
+    def update(self, update_dict):
+        for k, v in update_dict.items():
+            self.__setattr__(k, v)
+
+    def make_dict(self):
+        d = {}
+        for f in self._ALLOWED_FIELDS:
+            if hasattr(self, f):
+                value = getattr(self, f)
+                if isinstance(value, Configuration):
+                    value = value.make_dict()
+                d[f] = value
+        return d
+
+
+class StreamConfiguration(Configuration):
+    _ALLOWED_FIELDS = ("size", "format", "stride", "framesize")
+    _FIELD_CLASS_MAP = {}
+    _FORWARD_FIELDS = {}
+
+
+class CameraConfiguration(Configuration):
+    _ALLOWED_FIELDS = ("use_case", "buffer_count", "transform", "display", "encode", "colour_space", "controls", "main", "lores", "raw")
+    _FIELD_CLASS_MAP = {"main": StreamConfiguration, "lores": StreamConfiguration, "raw": StreamConfiguration}
+    _FORWARD_FIELDS = {"size": "main", "format": "main"}

--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -1,3 +1,4 @@
+from .controls import Controls
 
 class Configuration:
     """
@@ -68,7 +69,7 @@ class Configuration:
         for f in self._ALLOWED_FIELDS:
             if hasattr(self, f):
                 value = getattr(self, f)
-                if isinstance(value, Configuration):
+                if value is not None and f in self._FIELD_CLASS_MAP:
                     value = value.make_dict()
                 d[f] = value
         return d
@@ -81,6 +82,15 @@ class StreamConfiguration(Configuration):
 
 
 class CameraConfiguration(Configuration):
+    def __make_controls__(controls):
+        return Controls(CameraConfiguration.__picam2__, controls)
+
     _ALLOWED_FIELDS = ("use_case", "buffer_count", "transform", "display", "encode", "colour_space", "controls", "main", "lores", "raw")
-    _FIELD_CLASS_MAP = {"main": StreamConfiguration, "lores": StreamConfiguration, "raw": StreamConfiguration}
+    _FIELD_CLASS_MAP = {"main": StreamConfiguration, "lores": StreamConfiguration, "raw": StreamConfiguration, "controls": __make_controls__}
     _FORWARD_FIELDS = {"size": "main", "format": "main"}
+
+    __picam2__ = None
+
+    @staticmethod
+    def set_picam2(picam2):
+        CameraConfiguration.__picam2__ = picam2

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+import threading
+
+from libcamera import ControlType, Size, Rectangle
+
+
+class Controls():
+
+    def __init__(self, picam2, controls={}):
+        self._picam2 = picam2
+        self._controls = []
+        self._lock = threading.Lock()
+        self.set_controls(controls)
+
+    def __setattr__(self, name, value):
+        if not name.startswith('_'):
+            if name not in self._picam2.camera_ctrl_info.keys():
+                raise RuntimeError(f"Control {name} is not advertied by libcamera")
+            self._controls.append(name)
+        self.__dict__[name] = value
+
+    def __enter__(self):
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self._lock.release()
+
+    def set_controls(self, controls):
+        with self._lock:
+            if isinstance(controls, dict):
+                for k, v in controls.items():
+                    self.__setattr__(k, v)
+            elif isinstance(controls, Controls):
+                for k in controls._controls:
+                    v = controls.__dict__[k]
+                    self.__setattr__(k, v)
+            else:
+                raise RuntimeError(f"Cannot update controls with {type(controls)} type")
+
+    def get_libcamera_controls(self):
+        libcamera_controls = {}
+        with self._lock:
+            for k in self._controls:
+                v = self.__dict__[k]
+                id = self._picam2.camera_ctrl_info[k][0]
+                if id.type == ControlType.Rectangle:
+                    v = Rectangle(*v)
+                elif id.type == ControlType.Size:
+                    v = Size(*v)
+                libcamera_controls[id] = v
+        return libcamera_controls
+
+    def make_dict(self):
+        dict_ = {}
+        with self._lock:
+            for k in self._controls:
+                v = self.__dict__[k]
+                dict_[k] = v
+        return dict_

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -19,6 +19,9 @@ class Controls():
             self._controls.append(name)
         self.__dict__[name] = value
 
+    def __repr__(self):
+        return f"<Controls: {self.make_dict()}>"
+
     def __enter__(self):
         self._lock.acquire()
         return self

--- a/picamera2/metadata.py
+++ b/picamera2/metadata.py
@@ -1,0 +1,10 @@
+
+class Metadata():
+    def __init__(self, metadata={}):
+        self.__dict__ = metadata.copy()
+
+    def __repr__(self):
+        return f"<Metadata: {self.__dict__}>"
+
+    def make_dict(self):
+        return self.__dict__.copy()

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -556,18 +556,7 @@ class Picamera2:
                 camera_config = self.still_configuration
             else:
                 camera_config = self.video_configuration
-            # Default values should have been set for everything, except perhaps lores/raw
-            # sizes and formats. So let's put something in there if they're empty.
-            if camera_config.lores is not None:
-                if camera_config.lores.size is None:
-                    camera_config.lores.size = camera_config.main.size
-                if camera_config.lores.format is None:
-                    camera_config.lores.format = "YUV420"
-            if camera_config.raw is not None:
-                if camera_config.raw.size is None:
-                    camera_config.raw.size = camera_config.main.size
-                if camera_config.raw.format is None:
-                    camera_config.raw.format = self.sensor_format
+            # We expect values to have been set for any lores/raw streams.
             camera_config = camera_config.make_dict()
         if camera_config is None:
             camera_config = self.create_preview_configuration()

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1063,9 +1063,11 @@ class Picamera2:
             raise RuntimeError("Must pass encoder instance")
         self._encoder = value
 
-    def start_recording(self, encoder, output) -> None:
+    def start_recording(self, encoder, output, config=None) -> None:
         """Start recording a video using the given encoder and to the given output.
         Output may be a string in which case the correspondingly named file is opened."""
+        if config is not None:
+            self.configure(config)
         if isinstance(output, str):
             output = FileOutput(output)
         encoder.output = output

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -574,8 +574,11 @@ class Picamera2:
         self.log.info("Configuration successful!")
         self.log.debug(f"Final configuration: {camera_config}")
 
-        # Update the properties list as some of the values may have changed.
+        # Update the controls and properties list as some of the values may have changed.
+        self.camera_ctrl_info = {}
         self.camera_properties_ = {}
+        for k, v in self.camera.controls.items():
+            self.camera_ctrl_info[k.name] = (k, v)
         for k in self.camera.properties.keys():
             self.camera_properties_[k.name] = k
 

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -16,7 +16,7 @@ from picamera2.outputs import FileOutput
 from picamera2.utils import initialize_logger
 from picamera2.previews import NullPreview, DrmPreview, QtPreview, QtGlPreview
 from .request import CompletedRequest
-
+from .configuration import CameraConfiguration, StreamConfiguration
 
 STILL = libcamera.StreamRole.StillCapture
 RAW = libcamera.StreamRole.Raw
@@ -76,6 +76,9 @@ class Picamera2:
         try:
             self.open_camera()
             self.log.debug(f"{self.camera_manager}")
+            self.preview_configuration = self.create_preview_configuration()
+            self.still_configuration = self.create_still_configuration()
+            self.video_configuration = self.create_video_configuration()
         except Exception:
             self.log.error("Camera __init__ sequence did not complete.")
             raise RuntimeError("Camera __init__ sequence did not complete.")
@@ -111,6 +114,30 @@ class Picamera2:
         self.lock = threading.Lock()  # protects the functions and completed_requests fields
         self.have_event_loop = False
         self.camera_properties_ = {}
+
+    @property
+    def preview_configuration(self):
+        return self.preview_configuration_
+
+    @preview_configuration.setter
+    def preview_configuration(self, value):
+        self.preview_configuration_ = CameraConfiguration(value)
+
+    @property
+    def still_configuration(self):
+        return self.still_configuration_
+
+    @still_configuration.setter
+    def still_configuration(self, value):
+        self.still_configuration_ = CameraConfiguration(value)
+
+    @property
+    def video_configuration(self):
+        return self.video_configuration_
+
+    @video_configuration.setter
+    def video_configuration(self, value):
+        self.video_configuration_ = CameraConfiguration(value)
 
     @property
     def request_callback(self):
@@ -485,10 +512,31 @@ class Picamera2:
         if self.raw_index >= 0:
             self.update_stream_config(camera_config["raw"], libcamera_config.at(self.raw_index))
 
-    def configure_(self, camera_config=None) -> None:
+    def configure_(self, camera_config="preview") -> None:
         """Configure the camera system with the given configuration."""
         if self.started:
             raise RuntimeError("Camera must be stopped before configuring")
+        initial_config = camera_config
+        if isinstance(initial_config, str):
+            if initial_config == "preview":
+                camera_config = self.preview_configuration
+            elif initial_config == "still":
+                camera_config = self.still_configuration
+            else:
+                camera_config = self.video_configuration
+            # Default values should have been set for everything, except perhaps lores/raw
+            # sizes and formats. So let's put something in there if they're empty.
+            if camera_config.lores is not None:
+                if camera_config.lores.size is None:
+                    camera_config.lores.size = camera_config.main.size
+                if camera_config.lores.format is None:
+                    camera_config.lores.format = "YUV420"
+            if camera_config.raw is not None:
+                if camera_config.raw.size is None:
+                    camera_config.raw.size = camera_config.main.size
+                if camera_config.raw.format is None:
+                    camera_config.raw.format = self.sensor_format
+            camera_config = camera_config.make_dict()
         if camera_config is None:
             camera_config = self.create_preview_configuration()
 
@@ -547,13 +595,20 @@ class Picamera2:
         # Mark ourselves as configured.
         self.libcamera_config = libcamera_config
         self.camera_config = camera_config
+        # Fill in the embedded configuration structures if those were used.
+        if initial_config == "preview":
+            self.preview_configuration.update(camera_config)
+        elif initial_config == "still":
+            self.still_configuration.update(camera_config)
+        else:
+            self.video_configuration.update(camera_config)
         # Set the controls directly so as to overwrite whatever is there. No need for the lock
         # here as the camera is not running. Copy it so that subsequent calls to set_controls
         # don't become part of the camera_config.
         self.controls = self.camera_config['controls'].copy()
         self.configure_count += 1
 
-    def configure(self, camera_config=None) -> None:
+    def configure(self, camera_config="preview") -> None:
         """Configure the camera system with the given configuration."""
         self.configure_(camera_config)
 

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -267,7 +267,7 @@ class Picamera2:
         config['display'] = display
         config['encode'] = encode
 
-    def preview_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=4, controls={}, display="main", encode="main"):
+    def create_preview_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=4, controls={}, display="main", encode="main"):
         "Make a configuration suitable for camera preview."
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -289,7 +289,7 @@ class Picamera2:
         self.add_display_and_encode(config, display, encode)
         return config
 
-    def still_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=1, controls={}, display=None, encode=None) -> dict:
+    def create_still_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=1, controls={}, display=None, encode=None) -> dict:
         "Make a configuration suitable for still image capture. Default to 2 buffers, as the Gl preview would need them."
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -311,7 +311,7 @@ class Picamera2:
         self.add_display_and_encode(config, display, encode)
         return config
 
-    def video_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=None, buffer_count=6, controls={}, display="main", encode="main") -> dict:
+    def create_video_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=None, buffer_count=6, controls={}, display="main", encode="main") -> dict:
         "Make a configuration suitable for video recording."
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -490,7 +490,7 @@ class Picamera2:
         if self.started:
             raise RuntimeError("Camera must be stopped before configuring")
         if camera_config is None:
-            camera_config = self.preview_configuration()
+            camera_config = self.create_preview_configuration()
 
         # Mark ourselves as unconfigured.
         self.libcamera_config = None

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -219,11 +219,12 @@ class Picamera2:
         else:
             raise RuntimeError("Failed to initialize camera")
 
-    def start_preview(self, preview=None, **kwargs) -> None:
+    def start_preview(self, preview=False, **kwargs) -> None:
         """
         Start the given preview which drives the camera processing. The preview
         may be either:
-          None - in which case a NullPreview is made,
+          None or False - in which case a NullPreview is made,
+          True - which we hope in future to use to autodetect
           a Preview enum value - in which case a preview of that type is made,
           or an actual preview object.
 
@@ -233,7 +234,17 @@ class Picamera2:
         if self.have_event_loop:
             raise RuntimeError("An event loop is already running")
 
-        if preview is None:
+        if preview:
+            # Crude attempt at "autodetection" but which will mostly (?) work. We will
+            # probably find situations that need fixing, VNC perhaps.
+            display = os.getenv('DISPLAY')
+            if display is None:
+                preview = Preview.DRM
+            elif display.startswith(':'):
+                preview = Preview.QTGL
+            else:
+                preview = Preview.QT
+        if not preview:  # i.e. None or False
             preview = NullPreview()
         elif isinstance(preview, Preview):
             preview_table = {Preview.NULL: NullPreview,
@@ -651,23 +662,29 @@ class Picamera2:
             self.log.error("Camera did not start properly.")
             raise RuntimeError("Camera did not start properly.")
 
-    def start(self, event_loop=True) -> None:
-        """Start the camera system running. Camera controls may be sent to the
+    def start(self, config=None, show_preview=False) -> None:
+        """
+        Start the camera system running. Camera controls may be sent to the
         camera before it starts running.
 
-        Additionally the event_loop parameter will cause an event loop
-        to be started if there is not one running already. In this
-        case the event loop will not display a window of any kind. Applications
-        wanting a preview window should use start_preview before calling this
-        function.
+        The following parameters may be supplied:
 
-        An application could elect not to start an event loop at all,
-        in which in which case they would have to supply their own."""
+        config - if not None this is used to configure the camera. This is just a
+            convenience so that you don't have to call configure explicitly.
+
+        show_preview - whether to show a preview window. You can pass in the preview
+            type or True to attempt to autodetect. If left as False you'll get no
+            visible preview window but the "NULL preview" will still be run. The
+            value None would mean no event loop runs at all and you would have to
+            implement your own.
+        """
+        if config is not None:
+            self.configure(config)
         if self.camera_config is None:
             raise RuntimeError("Camera has not been configured")
         # By default we will create an event loop is there isn't one running already.
-        if event_loop and not self.have_event_loop:
-            self.start_preview(Preview.NULL)
+        if show_preview is not None and not self.have_event_loop:
+            self.start_preview(show_preview)
         self.start_()
 
     def stop_(self, request=None) -> None:

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -78,6 +78,7 @@ class Picamera2:
         try:
             self.open_camera()
             self.log.debug(f"{self.camera_manager}")
+            CameraConfiguration.set_picam2(self)
             self.preview_configuration = self.create_preview_configuration()
             self.still_configuration = self.create_still_configuration()
             self.video_configuration = self.create_video_configuration()
@@ -284,6 +285,7 @@ class Picamera2:
             self.libcamera_config = None
             self.streams = None
             self.stream_map = None
+            CameraConfiguration.set_picam2(None)
             self.log.info(f'Camera closed successfully.')
 
     def make_initial_stream_config(self, stream_config: dict, updates: dict) -> dict:

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -2,6 +2,7 @@ import time
 import threading
 
 from libcamera import Rectangle, Size
+from .controls import Controls
 
 from PIL import Image
 import numpy as np
@@ -118,12 +119,11 @@ class CompletedRequest:
                 # can't recycle it.
                 if self.stop_count == self.picam2.stop_count:
                     self.request.reuse()
-                    with self.picam2.controls_lock:
-                        controls = self.picam2.populate_libcamera_controls()
-                        for id, value in controls.items():
-                            self.request.set_control(id, value)
-                        self.picam2.controls = {}
-                        self.picam2.camera.queue_request(self.request)
+                    controls = self.picam2.controls.get_libcamera_controls()
+                    for id, value in controls.items():
+                        self.request.set_control(id, value)
+                    self.picam2.controls = Controls(self.picam2)
+                    self.picam2.camera.queue_request(self.request)
                 self.request = None
 
     def make_buffer(self, name):

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -18,14 +18,14 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 
 app = QApplication([])
 
 
 def on_button_clicked():
     button.setEnabled(False)
-    cfg = picam2.still_configuration()
+    cfg = picam2.create_still_configuration()
     picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False, signal_function=qpicamera2.signal_done)
 
 

--- a/tests/configurations.py
+++ b/tests/configurations.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+from picamera2 import Picamera2, CameraConfiguration
+
+picam2 = Picamera2()
+
+# We're going to set up some configuration structures, apply each one in
+# turn and see if it gave us the configuration we expected.
+
+picam2.preview_configuration.size = (800, 600)
+picam2.preview_configuration.format = "RGB888"
+picam2.preview_configuration.controls.ExposureTime = 10000
+
+picam2.video_configuration.main.size = (800, 480)
+picam2.video_configuration.main.format = "YUV420"
+picam2.video_configuration.controls.FrameRate = 25.0
+
+picam2.still_configuration.size = (1024, 768)
+picam2.still_configuration.enable_lores()
+picam2.still_configuration.lores.format = "YUV420"
+picam2.still_configuration.enable_raw()
+half_res = tuple([v // 2 for v in picam2.sensor_resolution])
+picam2.still_configuration.raw.size = half_res
+
+picam2.configure("preview")
+if picam2.controls.ExposureTime != 10000:
+    raise RuntimeError("exposure value was not set")
+config = CameraConfiguration(picam2.camera_configuration())
+if config.main.size != (800, 600):
+    raise RuntimeError("preview resolution incorrect")
+
+picam2.configure("video")
+if picam2.controls.FrameRate < 24.99 or picam2.controls.FrameRate > 25.01:
+    raise RuntimeError("framerate was not set")
+config = CameraConfiguration(picam2.camera_configuration())
+if config.size != (800, 480):
+    raise RuntimeError("video resolution incorrect")
+if config.format != "YUV420":
+    raise RuntimeError("video format incorrect")
+
+picam2.configure("still")
+config = CameraConfiguration(picam2.camera_configuration())
+if config.raw.size != half_res:
+    raise RuntimeError("still raw size incorrect")

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -6,7 +6,7 @@ def main():
     print("With context...")
     time.sleep(1)
     with Picamera2() as picam2:
-        preview = picam2.preview_configuration()
+        preview = picam2.create_preview_configuration()
         picam2.configure(preview)
         picam2.start()
         metadata = picam2.capture_file("context_test.jpg")
@@ -17,7 +17,7 @@ def main():
     print("Without context...")
     time.sleep(1)
     picam2 = Picamera2()
-    preview = picam2.preview_configuration()
+    preview = picam2.create_preview_configuration()
     picam2.configure(preview)
     picam2.start()
     metadata = picam2.capture_file("no_context_test.jpg")

--- a/tests/drm_preview_test.py
+++ b/tests/drm_preview_test.py
@@ -9,7 +9,7 @@ preview_type = Preview.DRM
 
 print("First preview...")
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
 time.sleep(2)
@@ -18,7 +18,7 @@ print("Done")
 
 print("Second preview...")
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
 time.sleep(2)

--- a/tests/preview_cycle_test.py
+++ b/tests/preview_cycle_test.py
@@ -14,7 +14,7 @@ def main():
     preview = picam2.create_preview_configuration()
     picam2.configure(preview)
 
-    picam2.start(event_loop=False)
+    picam2.start(show_preview=None)
 
     qtgl1 = time.monotonic()
     print("QT GL Preview")

--- a/tests/preview_cycle_test.py
+++ b/tests/preview_cycle_test.py
@@ -11,7 +11,7 @@ def main():
     picam2 = Picamera2()
 
     #Let's set it up for previewing.
-    preview = picam2.preview_configuration()
+    preview = picam2.create_preview_configuration()
     picam2.configure(preview)
 
     picam2.start(event_loop=False)

--- a/tests/preview_location_test.py
+++ b/tests/preview_location_test.py
@@ -3,7 +3,7 @@ import time
 
 print("Preview re-initialized after start.")
 picam2 = Picamera2()
-preview = picam2.preview_configuration()
+preview = picam2.create_preview_configuration()
 picam2.configure(preview)
 picam2.start_preview(Preview.QT)
 picam2.start()
@@ -17,7 +17,7 @@ picam2.close()
 
 print("Preview initialized before start.")
 picam2 = Picamera2()
-preview = picam2.preview_configuration()
+preview = picam2.create_preview_configuration()
 picam2.configure(preview)
 picam2.start_preview(Preview.QT)
 picam2.start()

--- a/tests/qt_gl_preview_test.py
+++ b/tests/qt_gl_preview_test.py
@@ -10,7 +10,7 @@ preview_type = Preview.QTGL
 
 print("First preview...")
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
 time.sleep(2)
@@ -19,7 +19,7 @@ print("Done")
 
 print("Second preview...")
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
 time.sleep(2)

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -20,13 +20,16 @@ examples/preview.py
 examples/preview_x_forwarding.py
 examples/raw.py
 examples/rotation.py
+examples/still_capture_with_config.py
 examples/still_during_video.py
 examples/switch_mode.py
 examples/switch_mode_2.py
 examples/tuning_file.py
+examples/video_with_config.py
 examples/window_offset.py
 examples/zoom.py
 tests/app_test.py
+tests/configurations.py
 tests/context_test.py
 tests/preview_cycle_test.py
 tests/preview_location_test.py


### PR DESCRIPTION
This serious of commits implements most of the proposed changes. In particular

* The `Picamera2.xxx_configuration()` functions have become `Picamera2.create_xxx_configuration()`.
* Object-style configuration has been introduced for users who prefer this style of syntax.
* A number of functions have acquired extra optional parameters so as to reduce the necessary "boilerplate" in starting the camera.
* Controls have also acquired an optional object-style syntax.

I haven't yet looked at choosing encoders or the correct form of output object from a filename yet. There is still some auto-configuration for encoders (such as calculating a bitrate automatically) to be implemented.