### PR TITLE
API changes for the Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@
 
 ### Added
 
+* A very trivial Metadata class is provided that can be used to wrap the metadata dictionaries, for those that prefer this style.
+* A Controls class is provided which gives an object-like view to control lists. The class is able to check that the control names are valid.
+* Configuration structures are provided so that the Picamera2 object can be configured using the "object" style. Three such instances are embedded in the Picamera2 object, namely preview_configuration, still_configuration and video_configuration.
+
 ### Changed
+
+* The start_recording() method accepts an optional configuration.
+* The start_preview() method accepts True as an indication to try and autodetect the correct type of preview window. Note that there will be situations where it guesses incorrectly.
+* The start() method can optionally be given config and show_preview parameters which will configure the camera and start the preview (if it isn't running already).
+* Streams no longer have their widths optimally aligned by default. A separate align_configuration() method can be called to enforce this.
+* The preview_configuration(), still_configuration() and video_configuration() methods (xxx_configuration) are renamed to create_xxx_configuration().
 
 ## 0.2.2 Alpha Release 2
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ The imaging hardware on the Pi is capable of supplying up to 3 image streams to 
 
 After opening the camera, *Picamera2* must be configured with the `Picamera2.configure` method. It provides three methods for generating suitable configurations:
 
-- `Picamera2.preview_configuration` generates configurations normally suitable for camera preview.
-- `Picamera2.still_configuration` generates configurations normally suitable for still image capture.
-- `Picamera2.video_configuration` generates configurations for video recording.
+- `Picamera2.create_preview_configuration` generates configurations normally suitable for camera preview.
+- `Picamera2.create_still_configuration` generates configurations normally suitable for still image capture.
+- `Picamera2.create_video_configuration` generates configurations for video recording.
 
 In all cases, these functions can generate configurations with no user arguments at all. Otherwise the user may supply the following parameters:
 
@@ -148,38 +148,38 @@ Examples:
 
 Configure a default resolution preview.
 ```
-config = picam2.preview_configuration()
+config = picam2.create_preview_configuration()
 picam2.configure(config)
 ```
 
 Configure for a full resolution capture.
 ```
-config = picam2.still_configuration()
+config = picam2.create_still_configuration()
 picam2.configure(config)
 ```
 
 Here we configure both a VGA preview (*main*) stream, and a QVGA low resolution (*lores*) stream.
 ```
-config = picam2.preview_configuration(main={"size": (640, 480)},
+config = picam2.create_preview_configuration(main={"size": (640, 480)},
                                       lores={"size": (320, 240), "format": "YUV420"})
 picam2.configure(config)
 ```
 
 Ask for an additional raw stream at the sensor resolution. This will force the camera to run at the maximum resolution, probably at a reduced framerate. Without the size parameter (just `raw={}`) the raw frame would be the one that *libcamera* would naturally choose for the resolution of the main stream (probably much smaller).
 ```
-config = picam2.preview_configuration(raw={"size": picam2.sensor_resolution})
+config = picam2.create_preview_configuration(raw={"size": picam2.sensor_resolution})
 picam2.configure(config)
 ```
 
 Rotate all the images by 180 degrees.
 ```
-config = picam2.preview_configuration(transform=libcamera.Transform(hflip=1, vflip=1))
+config = picam2.create_preview_configuration(transform=libcamera.Transform(hflip=1, vflip=1))
 picam2.configure(config)
 ```
 
 Still image capture normally configures only a single buffer, as this is all you need. But if you're doing some form of burst capture, increasing the buffer count may enable the application to receive images more quickly.
 ```
-config = picam2.still_configuration(buffer_count=3)
+config = picam2.create_still_configuration(buffer_count=3)
 picam2.configure(config)
 ```
 
@@ -204,7 +204,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-config = picam2.preview_configuration()
+config = picam2.create_preview_configuration()
 picam2.configure(config)
 
 picam2.start()
@@ -241,7 +241,7 @@ from picamera2 import Picamera2, Preview
 import numpy as np
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration({"size": (640, 480)}))
+picam2.configure(picam2.create_preview_configuration({"size": (640, 480)}))
 picam2.start_preview(Preview.QTGL)
 overlay = np.zeros((200, 200, 4), dtype=np.uint8)
 overlay[:100, 100:] = (255, 0, 0, 64)  # red
@@ -297,13 +297,13 @@ request.release()
 
 When switching to a full resolution capture, it's common to re-start the camera in preview mode afterwards. When capturing a whole request, however, you can't re-start the camera until you're finished with that request:
 ```
-capture_config = picam2.still_configuration()
+capture_config = picam2.create_still_configuration()
 request = picam2.switch_mode_capture_request_and_stop(capture_config)
 # The camera is stopped but we can use the request. Then return the request:
 request.release()
 # And the camera could be re-configured and restarted.
-preview_config = picam2.preview_configuration()
-picam2.configure(preview_configuration)
+preview_config = picam2.create_preview_configuration()
+picam2.configure(preview_config)
 picam2.start()
 ```
 
@@ -311,7 +311,7 @@ picam2.start()
 
 Picamera2 supports saving DNG files through the _PiDNG_ library. When capturing DNGs, you will need to specify that you want a raw stream. For example, if the camera is running a normal preview, the following snippet would switch to full resolution mode (with a raw stream) and capture a DNG file.
 ```
-capture_config = picam2.still_configuration(raw={})
+capture_config = picam2.create_still_configuration(raw={})
 picam2.switch_mode_and_capture_file(capture_config, "full-res.dng", name="raw")
 ```
 
@@ -364,7 +364,7 @@ There is a second version of this [app_capture2.py](examples/app_capture2.py) th
 
 This application starts a preview window and then performs a full resolution JPEG capture. The preview normally uses one of the camera's faster readout modes, so we have to pick a separate *capture* mode, and *switch* to it, for the final capture.
 
-The `Picamera2.preview_configuration` method is best for selecting camera modes suitable for previewing, and `Picamera2.still_configuration` is best for selecting high resolution still capture modes.
+The `Picamera2.create_preview_configuration` method is best for selecting camera modes suitable for previewing, and `Picamera2.create_still_configuration` is best for selecting high resolution still capture modes.
 
 ### [capture_image_full_res.py](examples/capture_image_full_res.py)
 

--- a/examples/app_capture.py
+++ b/examples/app_capture.py
@@ -14,14 +14,14 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 
 app = QApplication([])
 
 
 def on_button_clicked():
     if not picam2.async_operation_in_progress:
-        cfg = picam2.still_configuration()
+        cfg = picam2.create_still_configuration()
         picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False, signal_function=None)
     else:
         print("Busy!")

--- a/examples/app_capture2.py
+++ b/examples/app_capture2.py
@@ -18,14 +18,14 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 
 app = QApplication([])
 
 
 def on_button_clicked():
     button.setEnabled(False)
-    cfg = picam2.still_configuration()
+    cfg = picam2.create_still_configuration()
     picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False, signal_function=qpicamera2.signal_done)
 
 

--- a/examples/app_capture_overlay.py
+++ b/examples/app_capture_overlay.py
@@ -20,13 +20,13 @@ def cleanup():
 
 picam2 = Picamera2()
 picam2.post_callback = request_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 app = QApplication([])
 
 
 def on_button_clicked():
     if not picam2.async_operation_in_progress:
-        cfg = picam2.still_configuration()
+        cfg = picam2.create_still_configuration()
         picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False,
                                             signal_function=None)
     else:

--- a/examples/app_capture_request.py
+++ b/examples/app_capture_request.py
@@ -18,7 +18,7 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 
 app = QApplication([])
 

--- a/examples/app_recording.py
+++ b/examples/app_recording.py
@@ -16,7 +16,7 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.video_configuration(main={"size": (1280, 720)}))
+picam2.configure(picam2.create_video_configuration(main={"size": (1280, 720)}))
 
 app = QApplication([])
 

--- a/examples/audio_video_capture.py
+++ b/examples/audio_video_capture.py
@@ -6,7 +6,7 @@ from picamera2.encoders import H264Encoder
 from picamera2.outputs import FfmpegOutput
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration()
+video_config = picam2.create_video_configuration()
 picam2.configure(video_config)
 
 encoder = H264Encoder(10000000)

--- a/examples/capture_circular.py
+++ b/examples/capture_circular.py
@@ -9,7 +9,7 @@ from picamera2.outputs import CircularOutput
 
 lsize = (320, 240)
 picam2 = Picamera2()
-video_config = picam2.video_configuration(main={"size": (1280, 720), "format": "RGB888"},
+video_config = picam2.create_video_configuration(main={"size": (1280, 720), "format": "RGB888"},
                                           lores={"size": lsize, "format": "YUV420"})
 picam2.configure(video_config)
 picam2.start_preview()

--- a/examples/capture_circular_stream.py
+++ b/examples/capture_circular_stream.py
@@ -11,7 +11,7 @@ from picamera2.outputs import CircularOutput, FileOutput
 
 lsize = (320, 240)
 picam2 = Picamera2()
-video_config = picam2.video_configuration(main={"size": (1280, 720), "format": "RGB888"},
+video_config = picam2.create_video_configuration(main={"size": (1280, 720), "format": "RGB888"},
                                           lores={"size": lsize, "format": "YUV420"})
 picam2.configure(video_config)
 picam2.start_preview()

--- a/examples/capture_dng.py
+++ b/examples/capture_dng.py
@@ -9,8 +9,8 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
-capture_config = picam2.still_configuration(raw={})
+preview_config = picam2.create_preview_configuration()
+capture_config = picam2.create_still_configuration(raw={})
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/capture_dng_and_jpeg.py
+++ b/examples/capture_dng_and_jpeg.py
@@ -9,8 +9,8 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
-capture_config = picam2.still_configuration(raw={}, display=None)
+preview_config = picam2.create_preview_configuration()
+capture_config = picam2.create_still_configuration(raw={}, display=None)
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/capture_full_res.py
+++ b/examples/capture_full_res.py
@@ -9,8 +9,8 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
-capture_config = picam2.still_configuration()
+preview_config = picam2.create_preview_configuration()
+capture_config = picam2.create_still_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/capture_headless.py
+++ b/examples/capture_headless.py
@@ -3,7 +3,7 @@
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-config = picam2.still_configuration()
+config = picam2.create_still_configuration()
 picam2.configure(config)
 
 picam2.start()

--- a/examples/capture_image_full_res.py
+++ b/examples/capture_image_full_res.py
@@ -8,8 +8,8 @@ from picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
-preview_config = picam2.preview_configuration()
-capture_config = picam2.still_configuration()
+preview_config = picam2.create_preview_configuration()
+capture_config = picam2.create_still_configuration()
 
 picam2.configure(preview_config)
 picam2.start()

--- a/examples/capture_jpeg.py
+++ b/examples/capture_jpeg.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
 
-preview_config = picam2.preview_configuration(main={"size": (800, 600)})
+preview_config = picam2.create_preview_configuration(main={"size": (800, 600)})
 picam2.configure(preview_config)
 
 picam2.start_preview(Preview.QTGL)

--- a/examples/capture_mjpeg.py
+++ b/examples/capture_mjpeg.py
@@ -5,7 +5,7 @@ from picamera2 import Picamera2
 from picamera2.encoders import JpegEncoder
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration(main={"size": (1920, 1080)})
+video_config = picam2.create_video_configuration(main={"size": (1920, 1080)})
 picam2.configure(video_config)
 
 picam2.start_preview()

--- a/examples/capture_mjpeg_v4l2.py
+++ b/examples/capture_mjpeg_v4l2.py
@@ -5,7 +5,7 @@ from picamera2 import Picamera2
 from picamera2.encoders import MJPEGEncoder
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration()
+video_config = picam2.create_video_configuration()
 picam2.configure(video_config)
 
 encoder = MJPEGEncoder(10000000)

--- a/examples/capture_motion.py
+++ b/examples/capture_motion.py
@@ -11,8 +11,8 @@ from picamera2.outputs import FileOutput
 
 lsize = (320, 240)
 picam2 = Picamera2()
-video_config = picam2.video_configuration(main={"size": (1280, 720), "format": "RGB888"},
-                                          lores={"size": lsize, "format": "YUV420"})
+video_config = picam2.create_video_configuration(main={"size": (1280, 720), "format": "RGB888"},
+                                                 lores={"size": lsize, "format": "YUV420"})
 picam2.configure(video_config)
 encoder = H264Encoder(1000000)
 picam2.encoder = encoder

--- a/examples/capture_png.py
+++ b/examples/capture_png.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration(main={"size": (800, 600)})
+preview_config = picam2.create_preview_configuration(main={"size": (800, 600)})
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/capture_stream.py
+++ b/examples/capture_stream.py
@@ -8,7 +8,7 @@ from picamera2.encoders import H264Encoder
 from picamera2.outputs import FileOutput
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration({"size": (1280, 720)})
+video_config = picam2.create_video_configuration({"size": (1280, 720)})
 picam2.configure(video_config)
 encoder = H264Encoder(1000000)
 

--- a/examples/capture_stream_udp.py
+++ b/examples/capture_stream_udp.py
@@ -8,7 +8,7 @@ from picamera2.encoders import H264Encoder
 from picamera2.outputs import FileOutput
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration({"size": (1280, 720)})
+video_config = picam2.create_video_configuration({"size": (1280, 720)})
 picam2.configure(video_config)
 encoder = H264Encoder(1000000)
 

--- a/examples/capture_to_buffer.py
+++ b/examples/capture_to_buffer.py
@@ -6,8 +6,8 @@ import time
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-capture_config = picam2.still_configuration()
-picam2.configure(picam2.preview_configuration())
+capture_config = picam2.create_still_configuration()
+picam2.configure(picam2.create_preview_configuration())
 picam2.start()
 
 time.sleep(1)

--- a/examples/capture_video.py
+++ b/examples/capture_video.py
@@ -5,7 +5,7 @@ from picamera2 import Picamera2
 from picamera2.encoders import H264Encoder
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration()
+video_config = picam2.create_video_configuration()
 picam2.configure(video_config)
 
 encoder = H264Encoder(10000000)

--- a/examples/controls.py
+++ b/examples/controls.py
@@ -10,7 +10,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/controls_2.py
+++ b/examples/controls_2.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/controls_3.py
+++ b/examples/controls_3.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+
+# Example of setting controls using the "direct" attribute method.
+
+from picamera2 import Picamera2, Preview
+import time
+
+from picamera2.controls import Controls
+
+picam2 = Picamera2()
+picam2.start_preview(Preview.QTGL)
+
+preview_config = picam2.preview_configuration()
+picam2.configure(preview_config)
+
+picam2.start()
+time.sleep(1)
+
+with picam2.controls as ctrl:
+    ctrl.AnalogueGain = 6.0
+    ctrl.ExposureTime = 60000
+
+time.sleep(2)
+
+ctrls = Controls(picam2)
+ctrls.AnalogueGain = 1.0
+ctrls.ExposureTime = 10000
+picam2.set_controls(ctrls)
+
+time.sleep(2)

--- a/examples/easy_capture.py
+++ b/examples/easy_capture.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+
+# Capture one image with the default configurations.
+picam2.start_and_capture_file("test.jpg")
+
+# Capture 3 images. Use a 0.5 second delay after the first image.
+picam2.start_and_capture_files("test{:d}.jpg", num_files=3, delay=0.5)

--- a/examples/easy_video.py
+++ b/examples/easy_video.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python3
+
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+
+# Record a 5 second video.
+picam2.start_and_record_video("test.mp4", duration=5)

--- a/examples/exposure_fixed.py
+++ b/examples/exposure_fixed.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 controls = {"ExposureTime": 10000, "AnalogueGain": 1.0}
-preview_config = picam2.preview_configuration(controls=controls)
+preview_config = picam2.create_preview_configuration(controls=controls)
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/metadata.py
+++ b/examples/metadata.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/metadata_with_image.py
+++ b/examples/metadata_with_image.py
@@ -10,7 +10,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/mjpeg_server.py
+++ b/examples/mjpeg_server.py
@@ -84,7 +84,7 @@ class StreamingServer(socketserver.ThreadingMixIn, server.HTTPServer):
 
 
 picam2 = Picamera2()
-picam2.configure(picam2.video_configuration(main={"size": (640, 480)}))
+picam2.configure(picam2.create_video_configuration(main={"size": (640, 480)}))
 output = StreamingOutput()
 picam2.start_recording(JpegEncoder(), FileOutput(output))
 

--- a/examples/mp4_capture.py
+++ b/examples/mp4_capture.py
@@ -6,7 +6,7 @@ from picamera2.encoders import H264Encoder
 from picamera2.outputs import FfmpegOutput
 
 picam2 = Picamera2()
-video_config = picam2.video_configuration()
+video_config = picam2.create_video_configuration()
 picam2.configure(video_config)
 
 encoder = H264Encoder(10000000)

--- a/examples/multiple_quality_capture.py
+++ b/examples/multiple_quality_capture.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+import time
+
+from picamera2.encoders import H264Encoder, Quality
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+video_config = picam2.create_video_configuration()
+picam2.configure(video_config)
+
+encoder = H264Encoder()
+
+picam2.start_recording(encoder, 'low.h264', quality=Quality.VERY_LOW)
+print(encoder._bitrate)
+time.sleep(5)
+picam2.stop_recording()
+
+picam2.start_recording(encoder, 'medium.h264', quality=Quality.MEDIUM)
+print(encoder._bitrate)
+time.sleep(5)
+picam2.stop_recording()
+
+picam2.start_recording(encoder, 'high.h264', quality=Quality.VERY_HIGH)
+print(encoder._bitrate)
+time.sleep(5)
+picam2.stop_recording()

--- a/examples/ocr.py
+++ b/examples/ocr.py
@@ -12,7 +12,7 @@ import pytesseract
 from picamera2 import MappedArray, Picamera2, Preview
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration({"size": (1024, 768)}))
+picam2.configure(picam2.create_preview_configuration({"size": (1024, 768)}))
 picam2.start_preview(Preview.QTGL)
 picam2.start()
 

--- a/examples/opencv_face_detect.py
+++ b/examples/opencv_face_detect.py
@@ -10,7 +10,7 @@ face_detector = cv2.CascadeClassifier("/usr/share/opencv4/haarcascades/haarcasca
 cv2.startWindowThread()
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration(main={"format": 'XRGB8888', "size": (640, 480)}))
+picam2.configure(picam2.create_preview_configuration(main={"format": 'XRGB8888', "size": (640, 480)}))
 picam2.start()
 
 while True:

--- a/examples/opencv_face_detect_2.py
+++ b/examples/opencv_face_detect_2.py
@@ -22,7 +22,7 @@ def draw_faces(request):
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
-config = picam2.preview_configuration(main={"size": (640, 480)},
+config = picam2.create_preview_configuration(main={"size": (640, 480)},
                                       lores={"size": (320, 240), "format": "YUV420"})
 picam2.configure(config)
 

--- a/examples/opencv_face_detect_3.py
+++ b/examples/opencv_face_detect_3.py
@@ -23,7 +23,7 @@ def draw_faces(request):
 
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
-config = picam2.preview_configuration(main={"size": (640, 480)},
+config = picam2.create_preview_configuration(main={"size": (640, 480)},
                                       lores={"size": (320, 240), "format": "YUV420"})
 picam2.configure(config)
 

--- a/examples/opencv_mertens_merge.py
+++ b/examples/opencv_mertens_merge.py
@@ -11,7 +11,7 @@ from picamera2 import Picamera2
 RATIO = 3.0
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start()
 
 # Run for a second to get a reasonable "middle" exposure level.
@@ -21,7 +21,7 @@ exposure_normal = metadata["ExposureTime"]
 gain = metadata["AnalogueGain"] * metadata["DigitalGain"]
 picam2.stop()
 controls = {"ExposureTime": exposure_normal, "AnalogueGain": gain}
-capture_config = picam2.preview_configuration(main={"size": (1024, 768),
+capture_config = picam2.create_preview_configuration(main={"size": (1024, 768),
                                                     "format": "RGB888"},
                                               controls=controls)
 picam2.configure(capture_config)

--- a/examples/overlay_drm.py
+++ b/examples/overlay_drm.py
@@ -7,7 +7,7 @@ import numpy as np
 from picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(Preview.DRM)
 picam2.start()
 time.sleep(1)

--- a/examples/overlay_gl.py
+++ b/examples/overlay_gl.py
@@ -7,7 +7,7 @@ import numpy as np
 from picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(Preview.QTGL)
 picam2.start()
 time.sleep(1)

--- a/examples/overlay_null.py
+++ b/examples/overlay_null.py
@@ -7,7 +7,7 @@ import numpy as np
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start()
 time.sleep(1)
 

--- a/examples/overlay_qt.py
+++ b/examples/overlay_qt.py
@@ -7,7 +7,7 @@ import numpy as np
 from picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(Preview.QT)
 picam2.start()
 time.sleep(1)

--- a/examples/preview.py
+++ b/examples/preview.py
@@ -10,7 +10,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/preview_drm.py
+++ b/examples/preview_drm.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.DRM, x=100, y=100, width=640, height=480)
 
-preview_config = picam2.preview_configuration({"size": (640, 360)})
+preview_config = picam2.create_preview_configuration({"size": (640, 360)})
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/preview_null.py
+++ b/examples/preview_null.py
@@ -5,7 +5,7 @@ import time
 from picamera2 import Picamera2, Preview
 
 picam2 = Picamera2()
-config = picam2.preview_configuration()
+config = picam2.create_preview_configuration()
 picam2.configure(config)
 
 # In fact, picam2.start() would do this anyway for us:

--- a/examples/preview_x_forwarding.py
+++ b/examples/preview_x_forwarding.py
@@ -10,7 +10,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QT)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/raw.py
+++ b/examples/raw.py
@@ -8,7 +8,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration(raw={"size": picam2.sensor_resolution})
+preview_config = picam2.create_preview_configuration(raw={"size": picam2.sensor_resolution})
 print(preview_config)
 picam2.configure(preview_config)
 

--- a/examples/rotation.py
+++ b/examples/rotation.py
@@ -10,7 +10,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 preview_config["transform"] = libcamera.Transform(hflip=1, vflip=1)
 picam2.configure(preview_config)
 

--- a/examples/still_capture_with_config.py
+++ b/examples/still_capture_with_config.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+# Use the configuration structure method to do a full res capture.
+
+from picamera2 import Picamera2
+import time
+
+picam2 = Picamera2()
+
+# We don't really need to change anyhting, but let's mess around just as a test.
+picam2.preview_configuration.size = (800, 600)
+picam2.preview_configuration.format = "YUV420"
+picam2.still_configuration.size = (1600, 1200)
+picam2.still_configuration.enable_raw()
+picam2.still_configuration.raw.size = picam2.sensor_resolution
+
+picam2.start("preview", show_preview=True)
+time.sleep(2)
+
+picam2.switch_mode_and_capture_file("still", "test_full.jpg")

--- a/examples/still_during_video.py
+++ b/examples/still_during_video.py
@@ -12,7 +12,7 @@ picam2 = Picamera2()
 half_resolution = [dim // 2 for dim in picam2.sensor_resolution]
 main_stream = {"size": half_resolution}
 lores_stream = {"size": (640, 480)}
-video_config = picam2.video_configuration(main_stream, lores_stream, encode="lores")
+video_config = picam2.create_video_configuration(main_stream, lores_stream, encode="lores")
 picam2.configure(video_config)
 
 encoder = H264Encoder(10000000)

--- a/examples/switch_mode.py
+++ b/examples/switch_mode.py
@@ -9,13 +9,13 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()
 time.sleep(2)
 
-other_config = picam2.preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
+other_config = picam2.create_preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
 
 picam2.switch_mode(other_config)
 time.sleep(2)

--- a/examples/switch_mode_2.py
+++ b/examples/switch_mode_2.py
@@ -9,14 +9,14 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()
 time.sleep(2)
 picam2.stop()
 
-other_config = picam2.preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
+other_config = picam2.create_preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
 picam2.configure(other_config)
 
 picam2.start()

--- a/examples/tensorflow/real_time.py
+++ b/examples/tensorflow/real_time.py
@@ -130,7 +130,7 @@ def main():
 
     picam2 = Picamera2()
     picam2.start_preview(Preview.QTGL)
-    config = picam2.preview_configuration(main={"size": normalSize},
+    config = picam2.create_preview_configuration(main={"size": normalSize},
                                           lores={"size": lowresSize, "format": "YUV420"})
     picam2.configure(config)
 

--- a/examples/tensorflow/real_time_with_labels.py
+++ b/examples/tensorflow/real_time_with_labels.py
@@ -136,7 +136,7 @@ def main():
 
     picam2 = Picamera2()
     picam2.start_preview(Preview.QTGL)
-    config = picam2.preview_configuration(main={"size": normalSize},
+    config = picam2.create_preview_configuration(main={"size": normalSize},
                                           lores={"size": lowresSize, "format": "YUV420"})
     picam2.configure(config)
 

--- a/examples/timestamped_video.py
+++ b/examples/timestamped_video.py
@@ -8,7 +8,7 @@ from picamera2.encoders import H264Encoder
 from picamera2.outputs import FileOutput
 
 picam2 = Picamera2()
-picam2.configure(picam2.video_configuration())
+picam2.configure(picam2.create_video_configuration())
 
 colour = (0, 255, 0)
 origin = (0, 30)

--- a/examples/tuning_file.py
+++ b/examples/tuning_file.py
@@ -11,7 +11,7 @@ tuning = Picamera2.load_tuning_file("imx477.json")
 tuning["rpi.agc"]["exposure_modes"]["normal"] = {"shutter": [100, 66666], "gain": [1.0, 8.0]}
 
 picam2 = Picamera2(tuning=tuning)
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(Preview.QTGL)
 picam2.start()
 time.sleep(2)

--- a/examples/video_with_config.py
+++ b/examples/video_with_config.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+
+# Use the configuration structure method to do a full res capture.
+
+from picamera2 import Picamera2
+from picamera2.encoders import H264Encoder
+import time
+
+picam2 = Picamera2()
+
+# We don't really need to change anyhting, but let's mess around just as a test.
+picam2.video_configuration.size = (800, 480)
+picam2.video_configuration.format = "YUV420"
+encoder = H264Encoder(bitrate=1000000)
+
+picam2.start_recording(encoder, "test.h264", config="video")
+time.sleep(5)
+picam2.stop_recording()

--- a/examples/window_offset.py
+++ b/examples/window_offset.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL, x=100, y=200)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/examples/yuv_to_rgb.py
+++ b/examples/yuv_to_rgb.py
@@ -7,7 +7,7 @@ from picamera2 import Picamera2
 cv2.startWindowThread()
 
 picam2 = Picamera2()
-config = picam2.preview_configuration(lores={"size": (640, 480)})
+config = picam2.create_preview_configuration(lores={"size": (640, 480)})
 picam2.configure(config)
 picam2.start()
 

--- a/examples/zoom.py
+++ b/examples/zoom.py
@@ -9,7 +9,7 @@ from picamera2 import Picamera2, Preview
 picam2 = Picamera2()
 picam2.start_preview(Preview.QTGL)
 
-preview_config = picam2.preview_configuration()
+preview_config = picam2.create_preview_configuration()
 picam2.configure(preview_config)
 
 picam2.start()

--- a/picamera2/__init__.py
+++ b/picamera2/__init__.py
@@ -1,3 +1,4 @@
+from .configuration import CameraConfiguration, StreamConfiguration
 from .converters import YUV420_to_RGB
 from .picamera2 import Picamera2, Preview
 from .request import CompletedRequest, MappedArray

--- a/picamera2/__init__.py
+++ b/picamera2/__init__.py
@@ -1,4 +1,5 @@
 from .configuration import CameraConfiguration, StreamConfiguration
+from .controls import Controls
 from .converters import YUV420_to_RGB
 from .picamera2 import Picamera2, Preview
 from .request import CompletedRequest, MappedArray

--- a/picamera2/__init__.py
+++ b/picamera2/__init__.py
@@ -1,6 +1,7 @@
 from .configuration import CameraConfiguration, StreamConfiguration
 from .controls import Controls
 from .converters import YUV420_to_RGB
+from .metadata import Metadata
 from .picamera2 import Picamera2, Preview
 from .request import CompletedRequest, MappedArray
 

--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -74,6 +74,19 @@ class Configuration:
                 d[f] = value
         return d
 
+    def align(self, optimal=True):
+        if optimal:
+            # Adjust the image size so that all planes are a mutliple of 32 bytes wide.
+            # This matches the hardware behaviour and means we can be more efficient.
+            align = 32
+            if self.format in ("YUV420", "YVU420"):
+                align = 64  # because the UV planes will have half this alignment
+            elif self.format in ("XBGR8888", "XRGB8888"):
+                align = 16  # 4 channels per pixel gives us an automatic extra factor of 2
+        else:
+            align = 2
+        self.size = (self.size[0] - self.size[0] % align, self.size[1] - self.size[1] % 2)
+
 
 class StreamConfiguration(Configuration):
     _ALLOWED_FIELDS = ("size", "format", "stride", "framesize")
@@ -90,3 +103,9 @@ class CameraConfiguration(Configuration):
         # Can't convert "controls" dicts to Controls objects automatically, so do it here:
         d = {k: v if k != "controls" else Controls(picam2, v) for k, v in d.items()}
         super().__init__(d)
+
+    def align(self, optimal=True):
+        self.main.align(optimal)
+        if self.lores is not None:
+            self.lores.align(optimal)
+        # No sense trying to align the raw stream.

--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -1,0 +1,86 @@
+
+class Configuration:
+    """
+    A small wrapper class that can be used to turn our configuration dicts into real objects.
+    The constructor can make an empty object, or initialise from a dict. There is also the
+    make_dict() method which turns the object back into a dict.
+
+    Derived classes should define:
+
+    _ALLOWED_FIELDS: these are the only attributes that may be set, anything else will raise
+        an error. The idea is to help prevent typos.
+
+    _FIELD_CLASS_MAP: this allows you to turn a dict that we are given as a value (for some
+        field) into a Configuration object. For example if someone is setting a dict into a
+        field of a CameraConfiguration, you might want it to turn into a StreamConfiguration.
+
+        One of these fields can be set by doing (for example) camera_config.lores = {}, which
+        would be turned into a StreamConfiguration. Or for those averse to dicts, we allow
+        camera_config.enable_lores() instead.
+
+    _FORWARD_FIELDS: allows certain attribute names to be forwarded to another contained
+        object. For example, if someone wants to set CameraConfiguration.size they probably
+        mean to set CameraConfiguration.main.size. So it's a kind of helpful shorthand.
+    """
+    def __init__(self, d={}):
+        if isinstance(d, Configuration):
+            d = d.make_dict()
+        for k in self._ALLOWED_FIELDS:
+            self.__setattr__(k, None)
+        for k, v in d.items():
+            self.__setattr__(k, v)
+
+    def __setattr__(self, name, value):
+        if name in self._FORWARD_FIELDS:
+            target = self._FORWARD_FIELDS[name]
+            self.__getattribute__(target).__setattr__(name, value)
+        elif name in self._ALLOWED_FIELDS:
+            if name in self._FIELD_CLASS_MAP and isinstance(value, dict):
+                value = self._FIELD_CLASS_MAP[name](value)
+            super().__setattr__(name, value)
+        else:
+            raise RuntimeError(f"Invalid field '{name}'")
+
+    def __getattribute__(self, name):
+        prefix = "enable_"
+        if name.startswith(prefix) and len(name) > len(prefix):
+            field = name[len(prefix):]
+
+            def func(onoff=True):
+                if onoff:
+                    self.__setattr__(field, {})
+                else:
+                    delattr(self, field)
+            return func
+
+        else:
+            return super().__getattribute__(name)
+
+    def __repr__(self):
+        return type(self).__name__ + "(" + repr(self.make_dict()) + ")"
+
+    def update(self, update_dict):
+        for k, v in update_dict.items():
+            self.__setattr__(k, v)
+
+    def make_dict(self):
+        d = {}
+        for f in self._ALLOWED_FIELDS:
+            if hasattr(self, f):
+                value = getattr(self, f)
+                if isinstance(value, Configuration):
+                    value = value.make_dict()
+                d[f] = value
+        return d
+
+
+class StreamConfiguration(Configuration):
+    _ALLOWED_FIELDS = ("size", "format", "stride", "framesize")
+    _FIELD_CLASS_MAP = {}
+    _FORWARD_FIELDS = {}
+
+
+class CameraConfiguration(Configuration):
+    _ALLOWED_FIELDS = ("use_case", "buffer_count", "transform", "display", "encode", "colour_space", "controls", "main", "lores", "raw")
+    _FIELD_CLASS_MAP = {"main": StreamConfiguration, "lores": StreamConfiguration, "raw": StreamConfiguration}
+    _FORWARD_FIELDS = {"size": "main", "format": "main"}

--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -1,3 +1,4 @@
+from .controls import Controls
 
 class Configuration:
     """
@@ -68,7 +69,7 @@ class Configuration:
         for f in self._ALLOWED_FIELDS:
             if hasattr(self, f):
                 value = getattr(self, f)
-                if isinstance(value, Configuration):
+                if value is not None and f in self._FIELD_CLASS_MAP:
                     value = value.make_dict()
                 d[f] = value
         return d
@@ -84,3 +85,8 @@ class CameraConfiguration(Configuration):
     _ALLOWED_FIELDS = ("use_case", "buffer_count", "transform", "display", "encode", "colour_space", "controls", "main", "lores", "raw")
     _FIELD_CLASS_MAP = {"main": StreamConfiguration, "lores": StreamConfiguration, "raw": StreamConfiguration}
     _FORWARD_FIELDS = {"size": "main", "format": "main"}
+
+    def __init__(self, d={}, picam2=None):
+        # Can't convert "controls" dicts to Controls objects automatically, so do it here:
+        d = {k: v if k != "controls" else Controls(picam2, v) for k, v in d.items()}
+        super().__init__(d)

--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -16,8 +16,7 @@ class Configuration:
         field of a CameraConfiguration, you might want it to turn into a StreamConfiguration.
 
         One of these fields can be set by doing (for example) camera_config.lores = {}, which
-        would be turned into a StreamConfiguration. Or for those averse to dicts, we allow
-        camera_config.enable_lores() instead.
+        would be turned into a StreamConfiguration.
 
     _FORWARD_FIELDS: allows certain attribute names to be forwarded to another contained
         object. For example, if someone wants to set CameraConfiguration.size they probably
@@ -43,17 +42,8 @@ class Configuration:
             raise RuntimeError(f"Invalid field '{name}'")
 
     def __getattribute__(self, name):
-        prefix = "enable_"
-        if name.startswith(prefix) and len(name) > len(prefix):
-            field = name[len(prefix):]
-
-            def func(onoff=True):
-                if onoff:
-                    self.__setattr__(field, {})
-                else:
-                    delattr(self, field)
-            return func
-
+        if name in super().__getattribute__("_FORWARD_FIELDS"):
+            return super().__getattribute__(self._FORWARD_FIELDS[name]).__getattribute__(name)
         else:
             return super().__getattribute__(name)
 
@@ -103,6 +93,18 @@ class CameraConfiguration(Configuration):
         # Can't convert "controls" dicts to Controls objects automatically, so do it here:
         d = {k: v if k != "controls" else Controls(picam2, v) for k, v in d.items()}
         super().__init__(d)
+
+    def enable_lores(self, onoff=True):
+        if onoff:
+            self.lores = StreamConfiguration({"size": self.main.size, "format": "YUV420"})
+        else:
+            self.lores = None
+
+    def enable_raw(self, onoff=True):
+        if onoff:
+            self.raw = StreamConfiguration({"size": self.main.size, "format": None})
+        else:
+            self.raw = None
 
     def align(self, optimal=True):
         self.main.align(optimal)

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+import threading
+
+from libcamera import ControlType, Size, Rectangle
+
+
+class Controls():
+
+    def __init__(self, picam2, controls={}):
+        self._picam2 = picam2
+        self._controls = []
+        self._lock = threading.Lock()
+        self.set_controls(controls)
+
+    def __setattr__(self, name, value):
+        if not name.startswith('_'):
+            if name not in self._picam2.camera_ctrl_info.keys():
+                raise RuntimeError(f"Control {name} is not advertied by libcamera")
+            self._controls.append(name)
+        self.__dict__[name] = value
+
+    def __enter__(self):
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        self._lock.release()
+
+    def set_controls(self, controls):
+        with self._lock:
+            if isinstance(controls, dict):
+                for k, v in controls.items():
+                    self.__setattr__(k, v)
+            elif isinstance(controls, Controls):
+                for k in controls._controls:
+                    v = controls.__dict__[k]
+                    self.__setattr__(k, v)
+            else:
+                raise RuntimeError(f"Cannot update controls with {type(controls)} type")
+
+    def get_libcamera_controls(self):
+        libcamera_controls = {}
+        with self._lock:
+            for k in self._controls:
+                v = self.__dict__[k]
+                id = self._picam2.camera_ctrl_info[k][0]
+                if id.type == ControlType.Rectangle:
+                    v = Rectangle(*v)
+                elif id.type == ControlType.Size:
+                    v = Size(*v)
+                libcamera_controls[id] = v
+        return libcamera_controls
+
+    def make_dict(self):
+        dict_ = {}
+        with self._lock:
+            for k in self._controls:
+                v = self.__dict__[k]
+                dict_[k] = v
+        return dict_

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -19,6 +19,9 @@ class Controls():
             self._controls.append(name)
         self.__dict__[name] = value
 
+    def __repr__(self):
+        return f"<Controls: {self.make_dict()}>"
+
     def __enter__(self):
         self._lock.acquire()
         return self

--- a/picamera2/encoders/__init__.py
+++ b/picamera2/encoders/__init__.py
@@ -1,4 +1,4 @@
-from .encoder import Encoder
+from .encoder import Encoder, Quality
 from .h264_encoder import H264Encoder
 from .jpeg_encoder import JpegEncoder
 from .mjpeg_encoder import MJPEGEncoder

--- a/picamera2/encoders/encoder.py
+++ b/picamera2/encoders/encoder.py
@@ -1,8 +1,19 @@
 """Encoder functionality"""
 
+from enum import Enum
 from v4l2 import *
 
 from ..outputs import Output
+
+
+class Quality(Enum):
+    """Enum type to describe the quality wanted from an encoder. This may be passed
+    if a specific value (such as bitrate) has not been set."""
+    VERY_LOW = 0
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+    VERY_HIGH = 4
 
 
 class Encoder:

--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -1,5 +1,8 @@
 """H264 encoder functionality"""
 
+from math import sqrt
+from picamera2.encoders import Quality
+from picamera2.encoders.v4l2_encoder import V4L2Encoder
 from v4l2 import *
 
 from picamera2.encoders.v4l2_encoder import V4L2Encoder
@@ -8,10 +11,10 @@ from picamera2.encoders.v4l2_encoder import V4L2Encoder
 class H264Encoder(V4L2Encoder):
     """Uses functionality from V4L2Encoder"""
 
-    def __init__(self, bitrate, repeat=False, iperiod=None):
+    def __init__(self, bitrate=None, repeat=False, iperiod=None):
         """H264 Encoder
 
-        :param bitrate: Bitrate
+        :param bitrate: Bitrate, default None
         :type bitrate: int
         :param repeat: Repeat seq header, defaults to False
         :type repeat: bool, optional
@@ -23,3 +26,18 @@ class H264Encoder(V4L2Encoder):
             self._controls += [(V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, iperiod)]
         if repeat:
             self._controls += [(V4L2_CID_MPEG_VIDEO_REPEAT_SEQ_HEADER, 1)]
+
+    def _setup(self, quality):
+        if self._requested_bitrate is None:
+            # These are suggested bitrates for 1080p30 in Mbps
+            BITRATE_TABLE = {Quality.VERY_LOW: 2,
+                             Quality.LOW: 4,
+                             Quality.MEDIUM: 6,
+                             Quality.HIGH: 9,
+                             Quality.VERY_HIGH: 15}
+            reference_complexity = 1920 * 1080 * 30
+            actual_complexity = self.width * self.height * self.framerate
+            reference_bitrate = BITRATE_TABLE[quality] * 1000000
+            self._bitrate = int(reference_bitrate * sqrt(actual_complexity / reference_complexity))
+        else:
+            self._bitrate = self._requested_bitrate

--- a/picamera2/encoders/jpeg_encoder.py
+++ b/picamera2/encoders/jpeg_encoder.py
@@ -2,24 +2,25 @@
 
 import simplejpeg
 
+from picamera2.encoders import Quality
 from picamera2.encoders.multi_encoder import MultiEncoder
 
 
 class JpegEncoder(MultiEncoder):
     """Uses functionality from MultiEncoder"""
 
-    def __init__(self, num_threads=4, q=85, colour_space='RGBX'):
+    def __init__(self, num_threads=4, q=None, colour_space='RGBX'):
         """Initialises Jpeg encoder
 
         :param num_threads: Number of threads to use, defaults to 4
         :type num_threads: int, optional
-        :param q: Quality, defaults to 85
+        :param q: Quality, defaults to None
         :type q: int, optional
         :param colour_space: Colour space, defaults to 'RGBX'
         :type colour_space: str, optional
         """
         super().__init__(num_threads=num_threads)
-        self.q = q
+        self.requested_q = q
         self.colour_space = colour_space
 
     def encode_func(self, request, name):
@@ -34,3 +35,15 @@ class JpegEncoder(MultiEncoder):
         """
         array = request.make_array(name)
         return simplejpeg.encode_jpeg(array, quality=self.q, colorspace=self.colour_space)
+
+    def _setup(self, quality):
+        if self.requested_q is None:
+            # Image size and framerate isn't an issue here, you just get what you get.
+            Q_TABLE = {Quality.VERY_LOW: 20,
+                       Quality.LOW: 40,
+                       Quality.MEDIUM: 60,
+                       Quality.HIGH: 75,
+                       Quality.VERY_HIGH: 90}
+            self.q = Q_TABLE[quality]
+        else:
+            self.q = self.requested_q

--- a/picamera2/encoders/mjpeg_encoder.py
+++ b/picamera2/encoders/mjpeg_encoder.py
@@ -1,5 +1,8 @@
 """MJPEG encoder functionality utilising V4L2"""
 
+from math import sqrt
+from picamera2.encoders import Quality
+from picamera2.encoders.v4l2_encoder import V4L2Encoder
 from v4l2 import *
 
 from picamera2.encoders.v4l2_encoder import V4L2Encoder
@@ -8,10 +11,25 @@ from picamera2.encoders.v4l2_encoder import V4L2Encoder
 class MJPEGEncoder(V4L2Encoder):
     """MJPEG encoder utilsing V4L2 functionality"""
 
-    def __init__(self, bitrate):
+    def __init__(self, bitrate=None):
         """Creates MJPEG encoder
 
-        :param bitrate: Bitrate
+        :param bitrate: Bitrate, default None
         :type bitrate: int
         """
         super().__init__(bitrate, V4L2_PIX_FMT_MJPEG)
+
+    def _setup(self, quality):
+        if self._requested_bitrate is None:
+            # These are suggested bitrates for 1080p30 in Mbps
+            BITRATE_TABLE = {Quality.VERY_LOW: 6,
+                             Quality.LOW: 12,
+                             Quality.MEDIUM: 18,
+                             Quality.HIGH: 27,
+                             Quality.VERY_HIGH: 45}
+            reference_complexity = 1920 * 1080 * 30
+            actual_complexity = self.width * self.height * self.framerate
+            reference_bitrate = BITRATE_TABLE[quality] * 1000000
+            self._bitrate = int(reference_bitrate * sqrt(actual_complexity / reference_complexity))
+        else:
+            self._bitrate = self._requested_bitrate

--- a/picamera2/encoders/v4l2_encoder.py
+++ b/picamera2/encoders/v4l2_encoder.py
@@ -24,7 +24,8 @@ class V4L2Encoder(Encoder):
         """
         super().__init__()
         self.bufs = {}
-        self._bitrate = bitrate
+        # The encoder's _setup method will calculate the final bitrate.
+        self._requested_bitrate = bitrate
         self._pixformat = pixformat
         self._controls = []
         self.vd = None

--- a/picamera2/metadata.py
+++ b/picamera2/metadata.py
@@ -1,0 +1,10 @@
+
+class Metadata():
+    def __init__(self, metadata={}):
+        self.__dict__ = metadata.copy()
+
+    def __repr__(self):
+        return f"<Metadata: {self.__dict__}>"
+
+    def make_dict(self):
+        return self.__dict__.copy()

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -145,7 +145,7 @@ class Picamera2:
 
     @preview_configuration.setter
     def preview_configuration(self, value):
-        self.preview_configuration_ = CameraConfiguration(value)
+        self.preview_configuration_ = CameraConfiguration(value, self)
 
     @property
     def still_configuration(self):
@@ -153,7 +153,7 @@ class Picamera2:
 
     @still_configuration.setter
     def still_configuration(self, value):
-        self.still_configuration_ = CameraConfiguration(value)
+        self.still_configuration_ = CameraConfiguration(value, self)
 
     @property
     def video_configuration(self):
@@ -161,7 +161,7 @@ class Picamera2:
 
     @video_configuration.setter
     def video_configuration(self, value):
-        self.video_configuration_ = CameraConfiguration(value)
+        self.video_configuration_ = CameraConfiguration(value, self)
 
     @property
     def request_callback(self):

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -357,7 +357,7 @@ class Picamera2:
         config['display'] = display
         config['encode'] = encode
 
-    def preview_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=4, controls={}, display="main", encode="main"):
+    def create_preview_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=4, controls={}, display="main", encode="main"):
         """Make a configuration suitable for camera preview."""
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -379,7 +379,7 @@ class Picamera2:
         self.add_display_and_encode(config, display, encode)
         return config
 
-    def still_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=1, controls={}, display=None, encode=None) -> dict:
+    def create_still_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Jpeg(), buffer_count=1, controls={}, display=None, encode=None) -> dict:
         """Make a configuration suitable for still image capture. Default to 2 buffers, as the Gl preview would need them."""
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -401,7 +401,7 @@ class Picamera2:
         self.add_display_and_encode(config, display, encode)
         return config
 
-    def video_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=None, buffer_count=6, controls={}, display="main", encode="main") -> dict:
+    def create_video_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=None, buffer_count=6, controls={}, display="main", encode="main") -> dict:
         """Make a configuration suitable for video recording."""
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -597,7 +597,7 @@ class Picamera2:
         if self.started:
             raise RuntimeError("Camera must be stopped before configuring")
         if camera_config is None:
-            camera_config = self.preview_configuration()
+            camera_config = self.create_preview_configuration()
 
         # Mark ourselves as unconfigured.
         self.libcamera_config = None

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -662,18 +662,9 @@ class Picamera2:
             else:
                 camera_config = self.video_configuration
         if isinstance(camera_config, CameraConfiguration):
-            # Default values should have been set for everything, except perhaps lores/raw
-            # sizes and formats. So let's put something in there if they're empty.
-            if camera_config.lores is not None:
-                if camera_config.lores.size is None:
-                    camera_config.lores.size = camera_config.main.size
-                if camera_config.lores.format is None:
-                    camera_config.lores.format = "YUV420"
-            if camera_config.raw is not None:
-                if camera_config.raw.size is None:
-                    camera_config.raw.size = camera_config.main.size
-                if camera_config.raw.format is None:
-                    camera_config.raw.format = self.sensor_format
+            if camera_config.raw is not None and camera_config.raw.format is None:
+                camera_config.raw.format = self.sensor_format
+            # We expect values to have been set for any lores/raw streams.
             camera_config = camera_config.make_dict()
         if camera_config is None:
             camera_config = self.create_preview_configuration()

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -787,6 +787,8 @@ class Picamera2:
             value None would mean no event loop runs at all and you would have to
             implement your own.
         """
+        if self.camera_config is None and config is None:
+            config = "preview"
         if config is not None:
             self.configure(config)
         if self.camera_config is None:
@@ -1244,6 +1246,8 @@ class Picamera2:
         :param output: FileOutput object
         :type output: FileOutput
         """
+        if self.camera_config is None and config is None:
+            config = "video"
         if config is not None:
             self.configure(config)
         if isinstance(output, str):

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1227,7 +1227,7 @@ class Picamera2:
             raise RuntimeError("Must pass encoder instance")
         self._encoder = value
 
-    def start_recording(self, encoder, output) -> None:
+    def start_recording(self, encoder, output, config=None) -> None:
         """Start recording a video using the given encoder and to the given output.
 
         Output may be a string in which case the correspondingly named file is opened.
@@ -1237,6 +1237,8 @@ class Picamera2:
         :param output: FileOutput object
         :type output: FileOutput
         """
+        if config is not None:
+            self.configure(config)
         if isinstance(output, str):
             output = FileOutput(output)
         encoder.output = output

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -401,8 +401,10 @@ class Picamera2:
         if self.camera is None:
             raise RuntimeError("Camera not opened")
         main = self.make_initial_stream_config({"format": "XBGR8888", "size": (640, 480)}, main)
-        self.align_stream(main)
+        self.align_stream(main, optimal=False)
         lores = self.make_initial_stream_config({"format": "YUV420", "size": main["size"]}, lores)
+        if lores is not None:
+            self.align_stream(lores, optimal=False)
         raw = self.make_initial_stream_config({"format": self.sensor_format, "size": main["size"]}, raw)
         # Let the framerate vary from 12fps to as fast as possible.
         controls = {"NoiseReductionMode": libcamera.controls.draft.NoiseReductionModeEnum.Minimal,
@@ -423,8 +425,10 @@ class Picamera2:
         if self.camera is None:
             raise RuntimeError("Camera not opened")
         main = self.make_initial_stream_config({"format": "BGR888", "size": self.sensor_resolution}, main)
-        self.align_stream(main)
+        self.align_stream(main, optimal=False)
         lores = self.make_initial_stream_config({"format": "YUV420", "size": main["size"]}, lores)
+        if lores is not None:
+            self.align_stream(lores, optimal=False)
         raw = self.make_initial_stream_config({"format": self.sensor_format, "size": main["size"]}, raw)
         # Let the framerate span the entire possible range of the sensor.
         controls = {"NoiseReductionMode": libcamera.controls.draft.NoiseReductionModeEnum.HighQuality,
@@ -445,8 +449,10 @@ class Picamera2:
         if self.camera is None:
             raise RuntimeError("Camera not opened")
         main = self.make_initial_stream_config({"format": "XBGR8888", "size": (1280, 720)}, main)
-        self.align_stream(main)
+        self.align_stream(main, optimal=False)
         lores = self.make_initial_stream_config({"format": "YUV420", "size": main["size"]}, lores)
+        if lores is not None:
+            self.align_stream(lores, optimal=False)
         raw = self.make_initial_stream_config({"format": self.sensor_format, "size": main["size"]}, raw)
         if colour_space is None:
             # Choose default colour space according to the video resolution.
@@ -488,8 +494,11 @@ class Picamera2:
         else:
             if not self.is_YUV(format) and not self.is_RGB(format):
                 raise RuntimeError("Bad format " + format + " in stream " + name)
-        if type(stream_config["size"]) is not tuple or len(stream_config["size"]) != 2:
+        size = stream_config["size"]
+        if type(size) is not tuple or len(size) != 2:
             raise RuntimeError("size in " + name + " stream should be (width, height)")
+        if size[0] % 2 or size[1] % 2:
+            raise RuntimeError("width and height should be even")
 
     def check_camera_config(self, camera_config: dict) -> None:
         required_keys = ["colour_space", "transform", "main", "lores", "raw"]
@@ -556,16 +565,25 @@ class Picamera2:
 
         return libcamera_config
 
-    def align_stream(self, stream_config: dict) -> None:
-        # Adjust the image size so that all planes are a mutliple of 32 bytes wide.
-        # This matches the hardware behaviour and means we can be more efficient.
-        align = 32
-        if stream_config["format"] in ("YUV420", "YVU420"):
-            align = 64  # because the UV planes will have half this alignment
-        elif stream_config["format"] in ("XBGR8888", "XRGB8888"):
-            align = 16  # 4 channels per pixel gives us an automatic extra factor of 2
+    def align_stream(self, stream_config: dict, optimal=True) -> None:
+        if optimal:
+            # Adjust the image size so that all planes are a mutliple of 32 bytes wide.
+            # This matches the hardware behaviour and means we can be more efficient.
+            align = 32
+            if stream_config["format"] in ("YUV420", "YVU420"):
+                align = 64  # because the UV planes will have half this alignment
+            elif stream_config["format"] in ("XBGR8888", "XRGB8888"):
+                align = 16  # 4 channels per pixel gives us an automatic extra factor of 2
+        else:
+            align = 2
         size = stream_config["size"]
         stream_config["size"] = (size[0] - size[0] % align, size[1] - size[1] % 2)
+
+    def align_configuration(self, config: dict, optimal=True) -> None:
+        self.align_stream(config["main"], optimal=optimal)
+        if "lores" in config and config["lores"] is not None:
+            self.align_stream(config["lores"], optimal=optimal)
+        # No point aligning the raw stream, it wouldn't mean anything.
 
     def is_YUV(self, fmt) -> bool:
         return fmt in ("NV21", "NV12", "YUV420", "YVU420", "YVYU", "YUYV", "UYVY", "VYUY")

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -9,6 +9,7 @@ import tempfile
 import threading
 from enum import Enum
 from typing import List
+import time
 
 import libcamera
 import numpy as np
@@ -1275,3 +1276,83 @@ class Picamera2:
             if overlay.ndim != 3 or overlay.shape[2] != 4:
                 raise RuntimeError("Overlay must be a 4-channel image")
         self._preview.set_overlay(overlay)
+
+    def start_and_capture_files(self, name="image{:03d}.jpg", initial_delay=1, preview_mode="preview", capture_mode="still", num_files=1, delay=1, show_preview=True):
+        """
+        This function makes capturing multiple images more conenient, but should only be used in
+        command line line applications (not from a Qt application, for example). If will configure
+        the camera as requested and start it, switching between preview and still modes for
+        capture. It supports the following parameters (all optional):
+
+        name - name of the files to which to save the images. If more than one image is to be
+            captured then it should feature a format directive that will be replaced by a counter.
+
+        initial_delay - any time delay (in seconds) before the first image is captured. The camera
+            will run in preview mode during this period. The default time is 1s.
+
+        preview_mode - the camera mode to use for the preview phase (defaulting to the
+            Picamera2 object's preview_configuration field).
+
+        capture_mode - the camera mode to use to capture the still images (defaulting to the
+            Picamera2 object's still_configuration field).
+
+        num_files - number of files to capture (default 1).
+
+        delay - the time delay for every capture after the first (default 1s).
+
+        show_preview - whether to show a preview window (default: yes). The preview window only
+            displays an image by default during the preview phase, so if captures are back-to-back
+            with delay zero, then there may be no images shown. This parameter only has any
+            effect if a preview is not already running. If it is, it would have to be stopped first
+            (with the stop_preview method).
+        """
+        if self.started:
+            self.stop()
+        if delay:
+            # Show a preview between captures, so we will switch mode and back for each capture.
+            self.configure(preview_mode)
+            self.start(show_preview=show_preview)
+            for i in range(num_files):
+                time.sleep(initial_delay if i == 0 else delay)
+                self.switch_mode_and_capture_file(capture_mode, name.format(i))
+        else:
+            # No preview between captures, it's more efficient just to stay in capture mode.
+            if initial_delay:
+                self.configure(preview_mode)
+                self.start(show_preview=show_preview)
+                time.sleep(initial_delay)
+                self.switch_mode(capture_mode)
+            else:
+                self.configure(capture_mode)
+                self.start(show_preview=show_preview)
+            for i in range(num_files):
+                self.capture_file(name.format(i))
+                if i == num_files - 1:
+                    break
+                time.sleep(delay)
+        self.stop()
+
+    def start_and_capture_file(self, name="image.jpg", delay=1, preview_mode="preview", capture_mode="still", show_preview=True):
+        """
+        This function makes capturing a single image more conenient, but should only be used in
+        command line line applications (not from a Qt application, for example). If will configure
+        the camera as requested and start it, switching from the preview to the still mode for
+        capture. It supports the following parameters (all optional):
+
+        name - name of the file to which to save the images.
+
+        delay - any time delay (in seconds) before the image is captured. The camera
+            will run in preview mode during this period. The default time is 1s.
+
+        preview_mode - the camera mode to use for the preview phase (defaulting to the
+            Picamera2 object's preview_configuration field).
+
+        capture_mode - the camera mode to use to capture the still images (defaulting to the
+            Picamera2 object's still_configuration field).
+
+        show_preview - whether to show a preview window (default: yes). The preview window only
+            displays an image by default during the preview phase. This parameter only has any
+            effect if a preview is not already running. If it is, it would have to be stopped first
+            (with the stop_preview method).
+        """
+        self.start_and_capture_files(name=name, initial_delay=delay, preview_mode=preview_mode, capture_mode=capture_mode, num_files=1, show_preview=show_preview)

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -15,8 +15,8 @@ import libcamera
 import numpy as np
 from PIL import Image
 
-from picamera2.encoders import Encoder, Quality
-from picamera2.outputs import FileOutput
+from picamera2.encoders import Encoder, Quality, H264Encoder, MJPEGEncoder
+from picamera2.outputs import FileOutput, FfmpegOutput
 from picamera2.previews import DrmPreview, NullPreview, QtGlPreview, QtPreview
 from picamera2.utils import initialize_logger
 
@@ -1356,3 +1356,62 @@ class Picamera2:
             (with the stop_preview method).
         """
         self.start_and_capture_files(name=name, initial_delay=delay, preview_mode=preview_mode, capture_mode=capture_mode, num_files=1, show_preview=show_preview)
+
+    def start_and_record_video(self, output, encoder=None, config=None, quality=Quality.MEDIUM, show_preview=False, duration=0, audio=False):
+        """
+        This function makes video recording more convenient, but should only be used in command
+        line applications (not from a Qt application, for example). It will configure the camera
+        if requested and start it. The following parameters are required:
+
+        output - the name of an output file (or an output object). If the output is a string,
+            the correct output object will be created for "mp4" or "ts" files. All other formats
+            will simply be written as flat files.
+
+        The following parameters are optional:
+
+        encoder - the encoder object to use. If unspecified, the MJPEGEncoder will be selected for
+            files ending in ".mjpg" or .mjpeg", otherwise the H264Enccoder will be used.
+
+        config - the camera configuration to apply. The default behaviour (given by the value None)
+            is not to overwrite any existing configuration, though the "video" configuration will be
+            applied if the camera is unconfigured.
+
+        quality - an indication of the video quality to use. This will be ignored if the encoder
+            object was created with all its quality parameters (such as bitrate) filled in.
+
+        show_preview - whether to show a preview window (default: no). This parameter only has an
+            effect if a preview is not already running, in which case that preview would need
+            stopping first (using stop_preview) for any change to take effect.
+
+        duration - the duration of the video. The function will wait this amount of time before
+            stopping the recording and returning. The default behaviour is to return immediately
+            and to leave the recoding running (the application will have to stop it later, for
+            example by calling stop_recording).
+
+        audio - whether to record audio. This is only effective when recording to an "mp4" or "ts"
+            file, and there is a microphone installed and working as the default input device
+            through Pulseaudio.
+        """
+        if self.started:
+            self.stop()
+        if self.camera_config is None and config is None:
+            config = "video"
+        if config is not None:
+            self.configure(config)
+        if isinstance(output, str):
+            if encoder is None:
+                extension = output.split('.')[-1].lower()
+                if extension in ("mjpg", "mjpeg"):
+                    encoder = MJPEGEncoder()
+                if extension in ("mp4", "ts"):
+                    output = FfmpegOutput(output, audio=audio)
+                else:
+                    output = FileOutput(output)
+        if encoder is None:
+            encoder = H264Encoder()
+        encoder.output = output
+        self.start_encoder(encoder, quality)
+        self.start(show_preview=show_preview)
+        if duration:
+            time.sleep(duration)
+            self.stop_recording()

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -20,6 +20,7 @@ from picamera2.previews import DrmPreview, NullPreview, QtGlPreview, QtPreview
 from picamera2.utils import initialize_logger
 
 from .configuration import CameraConfiguration, StreamConfiguration
+from .controls import Controls
 from .request import CompletedRequest
 
 STILL = libcamera.StreamRole.StillCapture
@@ -128,8 +129,6 @@ class Picamera2:
         self.async_operation_in_progress = False
         self.asyc_result = None
         self.async_error = None
-        self.controls_lock = threading.Lock()
-        self.controls = {}
         self.options = {}
         self._encoder = None
         self.pre_callback = None
@@ -138,6 +137,7 @@ class Picamera2:
         self.lock = threading.Lock()  # protects the functions and completed_requests fields
         self.have_event_loop = False
         self.camera_properties_ = {}
+        self.controls = Controls(self)
 
     @property
     def preview_configuration(self):
@@ -725,10 +725,8 @@ class Picamera2:
             self.still_configuration.update(camera_config)
         else:
             self.video_configuration.update(camera_config)
-        # Set the controls directly so as to overwrite whatever is there. No need for the lock
-        # here as the camera is not running. Copy it so that subsequent calls to set_controls
-        # don't become part of the camera_config.
-        self.controls = self.camera_config['controls'].copy()
+        # Set the controls directly so as to overwrite whatever is there.
+        self.controls.set_controls(self.camera_config['controls'])
         self.configure_count += 1
 
     def configure(self, camera_config="preview") -> None:
@@ -747,24 +745,13 @@ class Picamera2:
         """List the controls supported by the camera."""
         return self.camera.controls
 
-    def populate_libcamera_controls(self):
-        controls = {}
-        for k, v in self.controls.items():
-            id = self.camera_ctrl_info[k][0]
-            if id.type == libcamera.ControlType.Rectangle:
-                v = libcamera.Rectangle(*v)
-            elif id.type == libcamera.ControlType.Size:
-                v = libcamera.Size(*v)
-            controls[id] = v
-        return controls
-
     def start_(self) -> None:
         """Start the camera system running."""
         if self.camera_config is None:
             raise RuntimeError("Camera has not been configured")
         if self.started:
             raise RuntimeError("Camera already started")
-        controls = self.populate_libcamera_controls()
+        controls = self.controls.get_libcamera_controls()
         if self.camera.start(controls) >= 0:
             for request in self.make_requests():
                 self.camera.queue_request(request)
@@ -837,9 +824,7 @@ class Picamera2:
 
     def set_controls(self, controls) -> None:
         """Set camera controls. These will be delivered with the next request that gets submitted."""
-        with self.controls_lock:
-            for key, value in controls.items():
-                self.controls[key] = value
+        self.controls.set_controls(controls)
 
     def get_completed_requests(self) -> List[CompletedRequest]:
         # Return all the requests that libcamera has completed.

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -683,8 +683,11 @@ class Picamera2:
         self.log.info("Configuration successful!")
         self.log.debug(f"Final configuration: {camera_config}")
 
-        # Update the properties list as some of the values may have changed.
+        # Update the controls and properties list as some of the values may have changed.
+        self.camera_ctrl_info = {}
         self.camera_properties_ = {}
+        for k, v in self.camera.controls.items():
+            self.camera_ctrl_info[k.name] = (k, v)
         for k, v in self.camera.properties.items():
             self.camera_properties_[k.name] = self._convert_from_libcamera_type(v)
 

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -1,6 +1,8 @@
 import threading
 import time
 
+from .controls import Controls
+
 from PIL import Image
 import numpy as np
 import piexif
@@ -118,12 +120,11 @@ class CompletedRequest:
                 # can't recycle it.
                 if self.stop_count == self.picam2.stop_count:
                     self.request.reuse()
-                    with self.picam2.controls_lock:
-                        controls = self.picam2.populate_libcamera_controls()
-                        for id, value in controls.items():
-                            self.request.set_control(id, value)
-                        self.picam2.controls = {}
-                        self.picam2.camera.queue_request(self.request)
+                    controls = self.picam2.controls.get_libcamera_controls()
+                    for id, value in controls.items():
+                        self.request.set_control(id, value)
+                    self.picam2.controls = Controls(self.picam2)
+                    self.picam2.camera.queue_request(self.request)
                 self.request = None
 
     def make_buffer(self, name):

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -19,14 +19,14 @@ def post_callback(request):
 
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-picam2.configure(picam2.preview_configuration(main={"size": (800, 600)}))
+picam2.configure(picam2.create_preview_configuration(main={"size": (800, 600)}))
 
 app = QApplication([])
 
 
 def on_button_clicked():
     button.setEnabled(False)
-    cfg = picam2.still_configuration()
+    cfg = picam2.create_still_configuration()
     picam2.switch_mode_and_capture_file(cfg, "test.jpg", wait=False, signal_function=qpicamera2.signal_done)
 
 

--- a/tests/configurations.py
+++ b/tests/configurations.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+from picamera2 import Picamera2, CameraConfiguration
+
+picam2 = Picamera2()
+
+# We're going to set up some configuration structures, apply each one in
+# turn and see if it gave us the configuration we expected.
+
+picam2.preview_configuration.size = (800, 600)
+picam2.preview_configuration.format = "RGB888"
+picam2.preview_configuration.controls.ExposureTime = 10000
+
+picam2.video_configuration.main.size = (800, 480)
+picam2.video_configuration.main.format = "YUV420"
+picam2.video_configuration.controls.FrameRate = 25.0
+
+picam2.still_configuration.size = (1024, 768)
+picam2.still_configuration.enable_lores()
+picam2.still_configuration.lores.format = "YUV420"
+picam2.still_configuration.enable_raw()
+half_res = tuple([v // 2 for v in picam2.sensor_resolution])
+picam2.still_configuration.raw.size = half_res
+
+picam2.configure("preview")
+if picam2.controls.ExposureTime != 10000:
+    raise RuntimeError("exposure value was not set")
+config = CameraConfiguration(picam2.camera_configuration(), picam2)
+if config.main.size != (800, 600):
+    raise RuntimeError("preview resolution incorrect")
+
+picam2.configure("video")
+if picam2.controls.FrameRate < 24.99 or picam2.controls.FrameRate > 25.01:
+    raise RuntimeError("framerate was not set")
+config = CameraConfiguration(picam2.camera_configuration(), picam2)
+if config.size != (800, 480):
+    raise RuntimeError("video resolution incorrect")
+if config.format != "YUV420":
+    raise RuntimeError("video format incorrect")
+
+picam2.configure("still")
+config = CameraConfiguration(picam2.camera_configuration(), picam2)
+if config.raw.size != half_res:
+    raise RuntimeError("still raw size incorrect")

--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -7,7 +7,7 @@ def main():
     print("With context...")
     time.sleep(1)
     with Picamera2() as picam2:
-        preview = picam2.preview_configuration()
+        preview = picam2.create_preview_configuration()
         picam2.configure(preview)
         picam2.start()
         metadata = picam2.capture_file("context_test.jpg")
@@ -16,7 +16,7 @@ def main():
     print("Without context...")
     time.sleep(1)
     picam2 = Picamera2()
-    preview = picam2.preview_configuration()
+    preview = picam2.create_preview_configuration()
     picam2.configure(preview)
     picam2.start()
     metadata = picam2.capture_file("no_context_test.jpg")

--- a/tests/drm_preview_test.py
+++ b/tests/drm_preview_test.py
@@ -10,7 +10,7 @@ preview_type = Preview.DRM
 
 print("First preview...")
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
 time.sleep(2)
@@ -19,7 +19,7 @@ print("Done")
 
 print("Second preview...")
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
 time.sleep(2)

--- a/tests/preview_cycle_test.py
+++ b/tests/preview_cycle_test.py
@@ -10,7 +10,7 @@ def main():
     picam2 = Picamera2()
 
     #Let's set it up for previewing.
-    preview = picam2.preview_configuration()
+    preview = picam2.create_preview_configuration()
     picam2.configure(preview)
 
     picam2.start(event_loop=False)

--- a/tests/preview_cycle_test.py
+++ b/tests/preview_cycle_test.py
@@ -13,7 +13,7 @@ def main():
     preview = picam2.create_preview_configuration()
     picam2.configure(preview)
 
-    picam2.start(event_loop=False)
+    picam2.start(show_preview=None)
 
     qtgl1 = time.monotonic()
     print("QT GL Preview")

--- a/tests/preview_location_test.py
+++ b/tests/preview_location_test.py
@@ -4,7 +4,7 @@ from picamera2 import Picamera2, Preview
 
 print("Preview re-initialized after start.")
 picam2 = Picamera2()
-preview = picam2.preview_configuration()
+preview = picam2.create_preview_configuration()
 picam2.configure(preview)
 picam2.start_preview(Preview.QT)
 picam2.start()
@@ -16,7 +16,7 @@ picam2.close()
 
 print("Preview initialized before start.")
 picam2 = Picamera2()
-preview = picam2.preview_configuration()
+preview = picam2.create_preview_configuration()
 picam2.configure(preview)
 picam2.start_preview(Preview.QT)
 picam2.start()

--- a/tests/qt_gl_preview_test.py
+++ b/tests/qt_gl_preview_test.py
@@ -10,7 +10,7 @@ preview_type = Preview.QTGL
 
 print("First preview...")
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
 time.sleep(2)
@@ -19,7 +19,7 @@ print("Done")
 
 print("Second preview...")
 picam2 = Picamera2()
-picam2.configure(picam2.preview_configuration())
+picam2.configure(picam2.create_preview_configuration())
 picam2.start_preview(preview_type)
 picam2.start()
 time.sleep(2)

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -8,6 +8,8 @@ examples/capture_to_buffer.py
 examples/capture_video.py
 examples/controls.py
 examples/controls_2.py
+examples/easy_capture.py
+examples/easy_video.py
 examples/exposure_fixed.py
 examples/metadata.py
 examples/mp4_capture.py

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -20,13 +20,16 @@ examples/preview.py
 examples/preview_x_forwarding.py
 examples/raw.py
 examples/rotation.py
+examples/still_capture_with_config.py
 examples/still_during_video.py
 examples/switch_mode.py
 examples/switch_mode_2.py
 examples/tuning_file.py
+examples/video_with_config.py
 examples/window_offset.py
 examples/zoom.py
 tests/app_test.py
+tests/configurations.py
 tests/context_test.py
 tests/preview_cycle_test.py
 tests/preview_location_test.py


### PR DESCRIPTION
This is quite a large number of commits that implements a number of additions and changes that were requested by the Foundation. We have:

* The ability optionally to use structures embedded in the Picamera2 object to configure the camera.
* The ability optionally to use objects to set control values instead of dictionaries.
* Some changes to allow the amount of boilerplate code to be reduced. For example, start() and start_recording() can optionally be given a camera configuration, and will configure the camera with default values if complete unconfigured. start() can also start a preview window.
* Video encoders can optionally be asked to calculate bitrates and quality parameters for themselves.
* There are some convenient "very high level" API functions which may suit some simple use cases for those who want to know less about what Picamera2 does ("start_and_capture_files", "start_and_record_video" etc.)
