### PR TITLE
Add convenience list of available sensor formats

### DIFF
--- a/picamera2/sensor_format.py
+++ b/picamera2/sensor_format.py
@@ -1,0 +1,19 @@
+import re
+
+
+class SensorFormat():
+    def __init__(self, fmt_string):
+        pixels, self.packing = fmt_string.split("_")
+        self.bit_depth = int(re.search("\\d+$", pixels).group())
+        self.arrangement = re.search("[RGB]+", pixels).group()
+
+    @property
+    def format(self):
+        return f"{self.unpacked}{f'_{self.packing}' if self.packing else ''}"
+
+    @property
+    def unpacked(self):
+        return f"S{self.arrangement}{self.bit_depth}"
+
+    def __repr__(self):
+        return self.format

--- a/picamera2/sensor_format.py
+++ b/picamera2/sensor_format.py
@@ -3,9 +3,13 @@ import re
 
 class SensorFormat():
     def __init__(self, fmt_string):
-        pixels, self.packing = fmt_string.split("_")
+        if "_" in fmt_string:
+            pixels, self.packing = fmt_string.split("_")
+        else:
+            pixels = fmt_string
+            self.packing = None
         self.bit_depth = int(re.search("\\d+$", pixels).group())
-        self.arrangement = re.search("[RGB]+", pixels).group()
+        self.bayer_order = re.search("[RGB]+", pixels).group()
 
     @property
     def format(self):
@@ -13,7 +17,7 @@ class SensorFormat():
 
     @property
     def unpacked(self):
-        return f"S{self.arrangement}{self.bit_depth}"
+        return f"S{self.bayer_order}{self.bit_depth}"
 
     def __repr__(self):
         return self.format


### PR DESCRIPTION
Add the read_formats() function, which reads the available raw formats,
their frame rates, and other parameters from the camera, and stores them
in available_formats.

Each format is stored as a dictionary with keys: format, unpacked,
bit_depth, size, fps, crop_limits, and exposure_limits.

Signed-off-by: William Vinnicombe <william.vinnicombe@raspberrypi.com>