### PR TITLE
Add 8bit bayer formats to is_Bayer check

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -593,7 +593,8 @@ class Picamera2:
         return fmt in ("BGR888", "RGB888", "XBGR8888", "XRGB8888")
 
     def is_Bayer(self, fmt) -> bool:
-        return fmt in ("SBGGR10", "SGBRG10", "SGRBG10", "SRGGB10",
+        return fmt in ("SBGGR8", "SGBRG8", "SGRBG8", "SRGGB8",
+                       "SBGGR10", "SGBRG10", "SGRBG10", "SRGGB10",
                        "SBGGR10_CSI2P", "SGBRG10_CSI2P", "SGRBG10_CSI2P", "SRGGB10_CSI2P",
                        "SBGGR12", "SGBRG12", "SGRBG12", "SRGGB12",
                        "SBGGR12_CSI2P", "SGBRG12_CSI2P", "SGRBG12_CSI2P", "SRGGB12_CSI2P")


### PR DESCRIPTION
The picamera2.is_Bayer function only checks for the 10 and 12 bit bayer formats. This adds the 8 bit bayer formats which can be output from the pi v2 camera, in order to support that.