### PR TITLE
Allow JpegEncoder to select colour subsampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+* JpegEncoder defaults to producing YUV420 output now, though the constructor allows other colour subsampling modes to be chosen.
+
 ## 0.2.3 Alpha Release 3
 
 ### Added

--- a/picamera2/encoders/jpeg_encoder.py
+++ b/picamera2/encoders/jpeg_encoder.py
@@ -9,7 +9,7 @@ from picamera2.encoders.multi_encoder import MultiEncoder
 class JpegEncoder(MultiEncoder):
     """Uses functionality from MultiEncoder"""
 
-    def __init__(self, num_threads=4, q=None, colour_space='RGBX'):
+    def __init__(self, num_threads=4, q=None, colour_space='RGBX', colour_subsampling='420'):
         """Initialises Jpeg encoder
 
         :param num_threads: Number of threads to use, defaults to 4
@@ -18,10 +18,14 @@ class JpegEncoder(MultiEncoder):
         :type q: int, optional
         :param colour_space: Colour space, defaults to 'RGBX'
         :type colour_space: str, optional
+        :param colour_subsampling: Colour subsampling, allows choice of YUV420, YUV422 or YUV444
+            outputs. Defaults to '420'.
+        :type colour_subsampling: str, optional
         """
         super().__init__(num_threads=num_threads)
         self.requested_q = q
         self.colour_space = colour_space
+        self.colour_subsampling = colour_subsampling
 
     def encode_func(self, request, name):
         """Performs encoding
@@ -34,7 +38,7 @@ class JpegEncoder(MultiEncoder):
         :rtype: bytes
         """
         array = request.make_array(name)
-        return simplejpeg.encode_jpeg(array, quality=self.q, colorspace=self.colour_space)
+        return simplejpeg.encode_jpeg(array, quality=self.q, colorspace=self.colour_space, colorsubsampling=self.colour_subsampling)
 
     def _setup(self, quality):
         if self.requested_q is None:


### PR DESCRIPTION
It now defaults to YUV420 as well, though YUV422 or YUV444 can still
be requested in the class constructor (pass colour_subsample as '422'
or '444').

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>