### PR TITLE
Remove encoder when reconfigured

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -757,6 +757,9 @@ class Picamera2:
         self.encode_stream_name = camera_config['encode']
         if self.encode_stream_name is not None and self.encode_stream_name not in camera_config:
             raise RuntimeError(f"Encode stream {self.encode_stream_name} was not defined")
+        elif self.encode_stream_name is None:
+            # If no encode stream then remove the encoder
+            self._encoder = None
 
         # Allocate all the frame buffers.
         self.streams = [stream_config.stream for stream_config in libcamera_config]


### PR DESCRIPTION
Set _encoder to None when reconfiguring the camera without an encode
stream, to prevent errors occurring when switching from capturing video
to a still configuration.

Signed-off-by: William Vinnicombe <william.vinnicombe@raspberrypi.com>