### PR TITLE
Fix bug in drm_preview overlays

### DIFF
--- a/picamera2/previews/drm_preview.py
+++ b/picamera2/previews/drm_preview.py
@@ -73,7 +73,7 @@ class DrmPreview(NullPreview):
             h, w, channels = overlay.shape
             # Should I be recycling these instead of making new ones all the time?
             new_fb = pykms.DumbFramebuffer(self.card, w, h, "AB24")
-            with mmap.mmap(new_fb.planes[0].fd, w * h * 4, mmap.MAP_SHARED, mmap.PROT_WRITE) as mm:
+            with mmap.mmap(new_fb.fd(0), w * h * 4, mmap.MAP_SHARED, mmap.PROT_WRITE) as mm:
                 mm.write(np.ascontiguousarray(overlay).data)
             self.overlay_new_fb = new_fb
 
@@ -125,7 +125,7 @@ class DrmPreview(NullPreview):
                     self.stop_count = picam2.stop_count
 
                 fmt = self.FMT_MAP[pixel_format]
-                fd = fb.planes[0].fd
+                fd = fb.fd(0)
                 stride = cfg.stride
                 if pixel_format in ("YUV420", "YVU420"):
                     h2 = height // 2


### PR DESCRIPTION
was trying to access the fd via the non-existent `planes` member. Instead use the fd(plane) accessor

Fixes https://github.com/raspberrypi/picamera2/issues/244

Using a DRM preview seemed to be broken, the frame buffer object having no `planes` member. After digging about a bit in https://github.com/tomba/kmsxx/ I noticed in particular https://github.com/tomba/kmsxx/blob/2236a8ccacdfed5ff5f6873ed6618eccf570193d/kms%2B%2B/inc/kms%2B%2B/framebuffer.h#L29 this suggest that the correct way to access an fd for the desired framebuffer plane is to use `fd(plane)` rather than `planes[plane].fd`. I have confirmed this fixed the issue for me and the example `https://github.com/raspberrypi/picamera2/blob/main/examples/overlay_drm.py` now works as intended.

Signed-off-by: Tim Kelsey tkelsey@protonmail.com