### PR TITLE
Fix bug displaying overlays using DRM preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+* Fixed bug displaying overlays using DRM (pykms seems to have changed underneath us).
 * There's been some refactoring which has changed the way asynchronous calls (with wait=False) work. You should now call picam2.wait() to obtain the result, and you can set the signal_function so that you can avoid calling it before it's finished. The previous fields like "async_result" have been removed.
 * JpegEncoder defaults to producing YUV420 output now, though the constructor allows other colour subsampling modes to be chosen.
 * Fix bug where framerates had to be integer values.

--- a/picamera2/previews/drm_preview.py
+++ b/picamera2/previews/drm_preview.py
@@ -73,7 +73,7 @@ class DrmPreview(NullPreview):
             h, w, channels = overlay.shape
             # Should I be recycling these instead of making new ones all the time?
             new_fb = pykms.DumbFramebuffer(self.card, w, h, "AB24")
-            with mmap.mmap(new_fb.planes[0].fd, w * h * 4, mmap.MAP_SHARED, mmap.PROT_WRITE) as mm:
+            with mmap.mmap(new_fb.fd(0), w * h * 4, mmap.MAP_SHARED, mmap.PROT_WRITE) as mm:
                 mm.write(np.ascontiguousarray(overlay).data)
             self.overlay_new_fb = new_fb
 


### PR DESCRIPTION
pykms seems to have changed.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>