### PR TITLE
Display transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* All the preview implementations now support a "display transform", allowing the preview image to be horizontally and/or vertically flipped (whilst not affecting the underlying image). The Picamer2.start_preview method allows a libcamera transform to be passed.
 * Added APIs to capture and copy buffers/arrays from multiple streams at once: capture_buffers, capture_arrays, switch_mode_and_capture_buffers, switch_mode_and_capture_arrays.
 * Allow entries from the sensor_modes property to be used directly as the raw stream configuration.
 * Support for version 2.0 tuning files, including a find_tuning_algo method to make them easier to use.

--- a/examples/display_transform_qtgl.py
+++ b/examples/display_transform_qtgl.py
@@ -1,0 +1,18 @@
+from picamera2 import Picamera2, Preview
+from libcamera import Transform
+import numpy as np
+import time
+
+picam2 = Picamera2()
+config = picam2.create_preview_configuration()
+picam2.configure(config)
+picam2.start_preview(Preview.QTGL, transform=Transform(hflip=1, vflip=1))
+picam2.start()
+
+overlay = np.zeros((300, 400, 4), dtype=np.uint8)
+overlay[:150, 200:] = (255, 0, 0, 64)
+overlay[150:, :200] = (0, 255, 0, 64)
+overlay[150:, 200:] = (0, 0, 255, 64)
+
+picam2.set_overlay(overlay)
+time.sleep(1)

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -24,7 +24,7 @@ class NullPreview:
                 callback = key.data
                 callback(picam2)
 
-    def __init__(self, x=None, y=None, width=None, height=None):
+    def __init__(self, x=None, y=None, width=None, height=None, transform=None):
         """Initialise null preview
 
         :param x: X position, defaults to None
@@ -35,6 +35,8 @@ class NullPreview:
         :type width: int, optional
         :param height: Height, defaults to None
         :type height: int, optional
+        :param transform: Transform, defaults to None
+        :type transform: libcamera.Transform, optional
         """
         # Ignore width and height as they are meaningless. We only accept them so as to
         # be a drop-in replacement for the Qt/DRM previews.

--- a/picamera2/previews/qt_previews.py
+++ b/picamera2/previews/qt_previews.py
@@ -63,7 +63,7 @@ class QtPreviewBase:
 class QtPreview(QtPreviewBase):
     def make_picamera2_widget(self, picam2, width=640, height=480, transform=None):
         from picamera2.previews.qt import QPicamera2
-        return QPicamera2(picam2, width=self.width, height=self.height)
+        return QPicamera2(picam2, width=self.width, height=self.height, transform=self.transform)
 
     def get_title(self):
         return "QtPreview"

--- a/picamera2/previews/qt_previews.py
+++ b/picamera2/previews/qt_previews.py
@@ -5,7 +5,7 @@ import picamera2.picamera2
 
 
 class QtPreviewBase:
-    def make_picamera2_widget(picam2, width=640, height=480):
+    def make_picamera2_widget(picam2, width=640, height=480, transform=None):
         pass
 
     def get_title():
@@ -19,7 +19,7 @@ class QtPreviewBase:
 
         self.app = QApplication([])
         self.size = (self.width, self.height)
-        self.qpicamera2 = self.make_picamera2_widget(picam2, width=self.width, height=self.height)
+        self.qpicamera2 = self.make_picamera2_widget(picam2, width=self.width, height=self.height, transform=self.transform)
         if self.x is not None and self.y is not None:
             self.qpicamera2.move(self.x, self.y)
         self.qpicamera2.setWindowTitle(self.get_title())
@@ -37,11 +37,12 @@ class QtPreviewBase:
         del self.qpicamera2
         del self.app
 
-    def __init__(self, x=None, y=None, width=640, height=480):
+    def __init__(self, x=None, y=None, width=640, height=480, transform=None):
         self.x = x
         self.y = y
         self.width = width
         self.height = height
+        self.transform = transform
 
     def start(self, picam2):
         self.event = threading.Event()
@@ -60,7 +61,7 @@ class QtPreviewBase:
 
 
 class QtPreview(QtPreviewBase):
-    def make_picamera2_widget(self, picam2, width=640, height=480):
+    def make_picamera2_widget(self, picam2, width=640, height=480, transform=None):
         from picamera2.previews.qt import QPicamera2
         return QPicamera2(picam2, width=self.width, height=self.height)
 
@@ -69,9 +70,9 @@ class QtPreview(QtPreviewBase):
 
 
 class QtGlPreview(QtPreviewBase):
-    def make_picamera2_widget(self, picam2, width=640, height=480):
+    def make_picamera2_widget(self, picam2, width=640, height=480, transform=None):
         from picamera2.previews.qt import QGlPicamera2
-        return QGlPicamera2(picam2, width=self.width, height=self.height)
+        return QGlPicamera2(picam2, width=self.width, height=self.height, transform=self.transform)
 
     def get_title(self):
         return "QtGlPreview"

--- a/tests/display_transform_null.py
+++ b/tests/display_transform_null.py
@@ -1,0 +1,18 @@
+from picamera2 import Picamera2, Preview
+from libcamera import Transform
+import numpy as np
+import time
+
+picam2 = Picamera2()
+config = picam2.create_preview_configuration()
+picam2.configure(config)
+picam2.start_preview(Preview.NULL, transform=Transform(hflip=1, vflip=1))
+picam2.start()
+
+overlay = np.zeros((300, 400, 4), dtype=np.uint8)
+overlay[:150, 200:] = (255, 0, 0, 64)
+overlay[150:, :200] = (0, 255, 0, 64)
+overlay[150:, 200:] = (0, 0, 255, 64)
+
+picam2.set_overlay(overlay)
+time.sleep(1)

--- a/tests/display_transform_qt.py
+++ b/tests/display_transform_qt.py
@@ -1,0 +1,18 @@
+from picamera2 import Picamera2, Preview
+from libcamera import Transform
+import numpy as np
+import time
+
+picam2 = Picamera2()
+config = picam2.create_preview_configuration()
+picam2.configure(config)
+picam2.start_preview(Preview.QT, transform=Transform(hflip=1, vflip=1))
+picam2.start()
+
+overlay = np.zeros((300, 400, 4), dtype=np.uint8)
+overlay[:150, 200:] = (255, 0, 0, 64)
+overlay[150:, :200] = (0, 255, 0, 64)
+overlay[150:, 200:] = (0, 0, 255, 64)
+
+picam2.set_overlay(overlay)
+time.sleep(1)

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -11,6 +11,7 @@ examples/capture_to_buffer.py
 examples/capture_video.py
 examples/controls.py
 examples/controls_2.py
+examples/display_transform_qtgl.py
 examples/easy_capture.py
 examples/easy_video.py
 examples/exposure_fixed.py
@@ -37,6 +38,8 @@ examples/zoom.py
 tests/app_test.py
 tests/configurations.py
 tests/context_test.py
+tests/display_transform_null.py
+tests/display_transform_qt.py
 tests/mode_test.py
 tests/preview_cycle_test.py
 tests/preview_location_test.py


### PR DESCRIPTION
This is a series of small commits that adds the ability to specify a transform (horizontal and/or vertical flips) that are applied to the images displayed in the preview windows or widgets. This purely transforms what is shown on the screen but does not affect the actual image that we get from the camera.

In all cases, a `libcamera.Transform` object can be passed to the `Picamera2.start_preview` function to activate the feature, e.g. 
```
from libcamera import Transform
picam2.start_preview(Preview.QTGL, transform=Transform(hflip=1))
```

There's a commit for each of the preview window implementations, followed by a final commit that adds some tests and updates the change log.