### PR TITLE
Remove GUI deps for default install

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All the necessary packages can now be installed via `apt` and `pip3`, so the fol
 sudo apt install -y python3-libcamera python3-kms++
 sudo apt install -y python3-pyqt5 python3-prctl libatlas-base-dev ffmpeg python3-pip
 pip3 install numpy --upgrade
-pip3 install picamera2
+pip3 install picamera2[gui]
 ```
 
 Or If you don't want the GUI dependencies:
@@ -29,7 +29,7 @@ Or If you don't want the GUI dependencies:
 sudo apt install -y python3-libcamera python3-kms++
 sudo apt install -y python3-prctl libatlas-base-dev ffmpeg libopenjp2-7 python3-pip
 pip3 install numpy --upgrade
-NOGUI=1 pip3 install picamera2
+pip3 install picamera2
 ```
 
 ## Contributing

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-import os
-
 from setuptools import setup
-
-reqs = ['numpy', 'PiDNG', 'piexif', 'pillow', 'simplejpeg', 'v4l2-python3', 'python-prctl']
-allreqs = reqs + ['pyopengl', 'PyQt5']
-if os.getenv('NOGUI', '0') == '1':
-    allreqs = reqs
 
 with open("README.md") as readme:
     long_description = readme.read()
@@ -40,4 +33,5 @@ setup(
     packages=['picamera2', 'picamera2.encoders', 'picamera2.outputs', 'picamera2.previews', 'picamera2.utils'],
     python_requires='>=3.9',
     licence='BSD 2-Clause License',
-    install_requires=allreqs)
+    install_requires=['numpy', 'PiDNG', 'piexif', 'pillow', 'simplejpeg', 'v4l2-python3', 'python-prctl'],
+    extras_require={"gui": ['pyopengl', 'PyQt5']})


### PR DESCRIPTION
To install with GUI deps, now do: pip3 install picamera2[gui]

Signed-off-by: Chris Richardson <christopher.richardson@raspberrypi.org>