### PR TITLE
Fix TensorFlow installation instructions

### DIFF
--- a/examples/tensorflow/real_time.py
+++ b/examples/tensorflow/real_time.py
@@ -9,7 +9,7 @@
 # Install necessary dependences before starting,
 #
 # $ sudo apt update
-# $ sudo apt install build-essentials
+# $ sudo apt install build-essential
 # $ sudo apt install libatlas-base-dev
 # $ sudo apt install python3-pip
 # $ pip3 install tflite-runtime

--- a/examples/tensorflow/real_time_with_labels.py
+++ b/examples/tensorflow/real_time_with_labels.py
@@ -9,7 +9,7 @@
 # Install necessary dependences before starting,
 #
 # $ sudo apt update
-# $ sudo apt install build-essentials
+# $ sudo apt install build-essential
 # $ sudo apt install libatlas-base-dev
 # $ sudo apt install python3-pip
 # $ pip3 install tflite-runtime


### PR DESCRIPTION
The instructions referred to the build-essentials package, but the
package is called build-essential without the s.

Signed-off-by: William Vinnicombe <william.vinnicombe@raspberrypi.com>