### PR TITLE
Clear any initial controls after they are sent when the camera starts

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -834,6 +834,7 @@ class Picamera2:
         if self.started:
             raise RuntimeError("Camera already started")
         controls = self.controls.get_libcamera_controls()
+        self.controls = Controls(self)
         if self.camera.start(controls) >= 0:
             for request in self._make_requests():
                 self.camera.queue_request(request)


### PR DESCRIPTION
Otherwise they get sent again with the first request. Not especially harmful but it might be confusing in future.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>