### PR TITLE
Fix framerate calculation in preparation for libcamera update

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -372,8 +372,8 @@ class Picamera2:
                 cam_mode["size"] = (size.width, size.height)
                 temp_config = self.create_preview_configuration(raw={"format": str(pix), "size": cam_mode["size"]})
                 self.configure(temp_config)
-                frameDurationLimits = [i for i in self.camera_controls["FrameDurationLimits"] if i != 0]
-                cam_mode["fps"] = round(1e6 / min(frameDurationLimits), 2)
+                frameDurationMin = self.camera_controls["FrameDurationLimits"][0]
+                cam_mode["fps"] = round(1e6 / frameDurationMin, 2)
                 cam_mode["crop_limits"] = self.camera_properties["ScalerCropMaximum"]
                 cam_mode["exposure_limits"] = tuple([i for i in self.camera_controls["ExposureTime"] if i != 0])
                 self.sensor_modes_.append(cam_mode)


### PR DESCRIPTION
The next version of libcamera has a "None" default for the framerate so the code previously here will fall over. We may as well fix this ahead of time as the new code is in fact slightly preferable anyway.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>