### PR TITLE
Fix DRM overlays when using fkms

### DIFF
--- a/picamera2/previews/drm_preview.py
+++ b/picamera2/previews/drm_preview.py
@@ -118,8 +118,12 @@ class DrmPreview(NullPreview):
             self.overlay_plane = self.resman.reserve_overlay_plane(self.crtc, pykms.PixelFormat.ABGR8888)
             if self.overlay_plane is None:
                 raise RuntimeError("Failed to reserve DRM overlay plane")
-            # Want "coverage" mode, not pre-multiplied alpha.
-            self.overlay_plane.set_prop("pixel blend mode", 1)
+            # Want "coverage" mode, not pre-multiplied alpha. fkms doesn't seem to have this
+            # property so we suppress the error, but it seems to have the right behaviour anyway.
+            try:
+                self.overlay_plane.set_prop("pixel blend mode", 1)
+            except RuntimeError:
+                pass
 
         if completed_request is not None:
             fb = completed_request.request.buffers[stream]


### PR DESCRIPTION
This is part of the fix for getting display overlays to work when using DRM with fkms (rather than kms). A Linux kernel update is also required, but this change will be needed too so that the code will run correctly.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>