### PR TITLE
Report metadata on preview window title bars

### DIFF
--- a/examples/title_bar.py
+++ b/examples/title_bar.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+
+from picamera2 import Picamera2
+import time
+
+picam2 = Picamera2()
+picam2.start(show_preview=True)
+time.sleep(0.5)
+
+# Or you could do this before starting the camera.
+picam2.title_fields = ["ExposureTime", "AnalogueGain", "DigitalGain"]
+time.sleep(2)
+
+# And you can change it too.
+picam2.title_fields = ["ColourTemperature", "ColourGains"]
+time.sleep(2)

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -80,3 +80,6 @@ class NullPreview:
         self.running = False
         self.thread.join()
         self.picam2 = None
+
+    def set_title_function(self, function):
+        pass

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -98,6 +98,7 @@ class QGlPicamera2(QWidget):
         self.current_request = None
         self.own_current = False
         self.stop_count = 0
+        self.title_function = None
         self.egl = EglState()
         if picam2.verbose_console:
             print("EGL {} {}".format(
@@ -358,6 +359,8 @@ class QGlPicamera2(QWidget):
     def handle_requests(self):
         request = self.picamera2.process_requests()
         if request:
+            if self.title_function is not None:
+                self.setWindowTitle(self.title_function(request.get_metadata()))
             if self.picamera2.display_stream_name is not None:
                 with self.lock:
                     eglMakeCurrent(self.egl.display, self.surface, self.surface, self.egl.context)

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -36,6 +36,7 @@ class QPicamera2(QGraphicsView):
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.enabled = True
+        self.title_function = None
 
         self.update_overlay_signal.connect(self.update_overlay)
         self.camera_notifier = QSocketNotifier(self.picamera2.camera_manager.event_fd,
@@ -147,6 +148,8 @@ class QPicamera2(QGraphicsView):
         if not request:
             return
 
+        if self.title_function is not None:
+            self.setWindowTitle(self.title_function(request.get_metadata()))
         camera_config = self.picamera2.camera_config
         if self.enabled and self.picamera2.display_stream_name is not None and camera_config is not None:
             stream_config = camera_config[self.picamera2.display_stream_name]

--- a/picamera2/previews/qt_previews.py
+++ b/picamera2/previews/qt_previews.py
@@ -59,6 +59,9 @@ class QtPreviewBase:
     def set_overlay(self, overlay):
         self.qpicamera2.set_overlay(overlay)
 
+    def set_title_function(self, function):
+        self.qpicamera2.title_function = function
+
 
 class QtPreview(QtPreviewBase):
     def make_picamera2_widget(self, picam2, width=640, height=480, transform=None):

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -32,6 +32,7 @@ examples/still_capture_with_config.py
 examples/still_during_video.py
 examples/switch_mode.py
 examples/switch_mode_2.py
+examples/title_bar.py
 examples/tuning_file.py
 examples/video_with_config.py
 examples/window_offset.py


### PR DESCRIPTION
This change allows users to specify which metadata fields they want reported on the title bar of preview windows (a bit like libcamera-apps do).

The first commit implements the feature, the second adds an example which we also include in the test set.