### PR TITLE
Test that Picamera2 objects free resources properly when closed

### DIFF
--- a/tests/close_test.py
+++ b/tests/close_test.py
@@ -1,0 +1,34 @@
+from picamera2 import Picamera2
+import subprocess
+import sys
+
+# First open/close several times in this process in various ways.
+
+
+def run_camera():
+    camera = Picamera2()
+    camera.start()
+    camera.stop()
+    camera.close()
+
+
+run_camera()
+
+with Picamera2() as picam2:
+    picam2.start()
+    picam2.stop()
+
+picam2 = Picamera2()
+picam2.start()
+picam2.stop()
+picam2.close()
+
+# Check that everything is released so other processes can use the camera.
+
+program = """from picamera2 import Picamera2
+picam2 = Picamera2()
+picam2.start()"""
+print("Start camera in separate process:")
+cmd = ['python3', '-c', program]
+p = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+p.wait()

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -39,6 +39,7 @@ examples/window_offset.py
 examples/zoom.py
 tests/app_test.py
 tests/check_timestamps.py
+tests/close_test.py
 tests/configurations.py
 tests/context_test.py
 tests/display_transform_null.py


### PR DESCRIPTION
After calling close() on the Picamera2 object we start the camera again in another process - which should work!

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>