### PR TITLE
Fix buffer sizes for MJPEG cameras

### DIFF
--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -21,9 +21,12 @@ class _MappedBuffer:
 
         # Check if the buffer is contiguous and find the total length.
         fd = self.__fb.planes[0].fd
+        planes_metadata = self.__fb.metadata.planes
         buflen = 0
-        for p in self.__fb.planes:
-            buflen = buflen + p.length
+        for p, p_metadata in zip(self.__fb.planes, planes_metadata):
+            # bytes_used is the same as p.length for regular frames, but correctly reflects
+            # the compressed image size for MJPEG cameras.
+            buflen = buflen + p_metadata.bytes_used
             if fd != p.fd:
                 raise RuntimeError('_MappedBuffer: Cannot map non-contiguous buffer!')
 


### PR DESCRIPTION
We now create a buffer with the correct length of the JPEG that it contains (usually some tens of KB) rather than the worst case size that was allocated (often hundreds of KB, or worse). Has no effect on uncompressed streams.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>