### PR TITLE
Request Queue Rework

### DIFF
--- a/picamera2/exceptions.py
+++ b/picamera2/exceptions.py
@@ -1,0 +1,3 @@
+class RequeueException(Exception):
+    def __init__(self):
+        super("This method needs to be run again")

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1023,7 +1023,8 @@ class Picamera2:
 
         if func:
             req = requests.pop(0)
-            self.log.debug(f"Execute function: {func} on {req}")
+            # TODO reset to debug
+            self.log.info(f"Execute function: {func} on {req}")
             try:
                 result = func(req)
                 fut.set_result(result)


### PR DESCRIPTION
New version of #83 and #83 as per requests of @davidplowman.

This PR makes the request flow of picamera2 much simpler by:
- Making the function queue 1:1 with a futures queue.
- Removing the "completed_requests" management
- Treating  `wait` and`signal_function` the same everywhere.

This is done by using  a `deque` primitive and using builtin behaviors of `Future` objects.  Calls into the async underbelly now queue and unspool cleanly, and multiple callers into the module are supported.