### PR TITLE
Support for `RequestCopy`

### DIFF
--- a/examples/capture_dng_and_jpeg_helpers.py
+++ b/examples/capture_dng_and_jpeg_helpers.py
@@ -3,6 +3,7 @@
 # Capture a DNG and a JPEG made from the same raw data.
 
 from picamera2 import Picamera2, Preview
+from picamera2.request import RequestCopy
 import time
 
 picam2 = Picamera2()
@@ -16,5 +17,7 @@ picam2.start()
 time.sleep(2)
 
 buffers, metadata = picam2.switch_mode_and_capture_buffers(capture_config, ["main", "raw"])
-picam2.helpers.save(picam2.helpers.make_image(buffers[0], capture_config["main"]), metadata, "full.jpg")
-picam2.helpers.save_dng(buffers[1], metadata, capture_config["raw"], "full.dng")
+
+request_like = RequestCopy(buffers, metadata, capture_config)
+request_like.save("full.jpg")
+request_like.save_dng("full.dng")

--- a/examples/capture_helpers.py
+++ b/examples/capture_helpers.py
@@ -3,6 +3,7 @@
 # Capture multiple representations of a captured frame.
 
 from picamera2 import Picamera2, Preview
+from picamera2.request import RequestCopy
 import time
 
 picam2 = Picamera2()
@@ -15,7 +16,10 @@ picam2.configure(preview_config)
 picam2.start()
 time.sleep(2)
 
-buffers, metadata = picam2.switch_mode_and_capture_buffers(capture_config, ["main"])
+buffers, metadata = picam2.switch_mode(capture_config, ["main"])
+request = picam2.capture_request()
+request_copy = request.copy()
+request.release()
 
-arr = picam2.helpers.make_array(buffers[0], capture_config["main"])
-image = picam2.helpers.make_image(buffers[0], capture_config["main"])
+arr = request_copy.make_array("main")
+image = request_copy.make_image("main")

--- a/examples/stack_raw.py
+++ b/examples/stack_raw.py
@@ -7,6 +7,7 @@
 
 import numpy as np
 from picamera2 import Picamera2
+from picamera2.request import RequestCopy
 from picamera2.sensor_format import SensorFormat
 
 
@@ -38,4 +39,6 @@ accumulated -= (num_frames - 1) * int(black_level)
 accumulated = accumulated.clip(0, 2 ** raw_format.bit_depth - 1).astype(np.uint16)
 accumulated = accumulated.view(np.uint8)
 metadata["ExposureTime"] = exposure_time
-picam2.helpers.save_dng(accumulated, metadata, config["raw"], "accumulated.dng")
+
+request_like = RequestCopy(accumulated, metadata, config['raw'])
+request_like.save_dng(accumulated, metadata, config["raw"], "accumulated.dng")

--- a/picamera2/encoders/encoder.py
+++ b/picamera2/encoders/encoder.py
@@ -122,9 +122,6 @@ class Encoder:
             if type(self) is Encoder:
                 """Currently allow any format that is
                 passed, when Encoder used directly.
-                We can't use Picamera2.is_raw(value) etc.
-                to validate formats here, as we get a circular import
-                when trying to import Picamera2
                 """
                 self._format = value
             else:

--- a/picamera2/formats.py
+++ b/picamera2/formats.py
@@ -1,0 +1,18 @@
+def is_YUV(fmt: str) -> bool:
+    return fmt in ("NV21", "NV12", "YUV420", "YVU420", "YVYU", "YUYV", "UYVY", "VYUY")
+
+def is_RGB(fmt: str) -> bool:
+    return fmt in ("BGR888", "RGB888", "XBGR8888", "XRGB8888")
+
+def is_Bayer(fmt: str) -> bool:
+    return fmt in ("SBGGR8", "SGBRG8", "SGRBG8", "SRGGB8",
+                    "SBGGR10", "SGBRG10", "SGRBG10", "SRGGB10",
+                    "SBGGR10_CSI2P", "SGBRG10_CSI2P", "SGRBG10_CSI2P", "SRGGB10_CSI2P",
+                    "SBGGR12", "SGBRG12", "SGRBG12", "SRGGB12",
+                    "SBGGR12_CSI2P", "SGBRG12_CSI2P", "SGRBG12_CSI2P", "SRGGB12_CSI2P")
+
+def is_mono(fmt: str) -> bool:
+    return fmt in ("R8", "R10", "R12", "R8_CSI2P", "R10_CSI2P", "R12_CSI2P")
+
+def is_raw(fmt: str) -> bool:
+    return is_Bayer(fmt) or is_mono(fmt)

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -26,7 +26,7 @@ import picamera2.formats as formats
 
 from .configuration import CameraConfiguration, StreamConfiguration
 from .controls import Controls
-from .request import CompletedRequest, Helpers
+from .request import CompletedRequest
 from .sensor_format import SensorFormat
 
 STILL = libcamera.StreamRole.StillCapture

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -233,7 +233,7 @@ class RequestTransforms(RequestLike):
         _log.info(f"Time taken for encode: {(end_time-start_time)*1000} ms.")
 
 
-class RequestCopy(RequestLike):
+class RequestCopy(RequestTransforms):
     def __init__(self, buffers: Dict[str, np.ndarray], metadata: dict, camera_config: dict):
         self._buffers = buffers
         self._metadata = deepcopy(metadata)
@@ -251,7 +251,7 @@ class RequestCopy(RequestLike):
         """Get the metadata associated with this frame"""
         return self._metadata
 
-class CompletedRequest(RequestLike):
+class CompletedRequest(RequestTransforms):
     def __init__(self, request, picam2):
         self.request = request
         self.ref_count = 1


### PR DESCRIPTION
Rework the `CompletedRequest` class to add a simple `.copy()` class method that returns a object with the same call structure that isn't backed by a `libcamera.request` object. This allows users to keep the useful `save_*` and `as_*` methods without holding a reference to a request object and keep the stream moving.

This required the following:
- Movement of `is_***()` methods to a top level module named `formats.py` to resolve circular import issues.
- Making a common ABC that both `CompletedRequest` and `RequestCopy` derive from