### PR TITLE
Memory improvements in app_full.py

### DIFF
--- a/apps/app_full.py
+++ b/apps/app_full.py
@@ -61,7 +61,10 @@ def post_callback(request):
 # Set up camera and application
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-still_kwargs = {"lores": {}, "display": "lores", "encode": "lores", "buffer_count": 1}
+lores_size = picam2.sensor_resolution
+while lores_size[0] > 1600:
+    lores_size = (lores_size[0] // 2 & ~1, lores_size[1] // 2 & ~1)
+still_kwargs = {"lores": {"size": lores_size}, "display": "lores", "encode": "lores", "buffer_count": 1}
 picam2.still_configuration = picam2.create_still_configuration(
     **still_kwargs
 )


### PR DESCRIPTION
We reduce the size of the lores stream that we allocate for stills captures. Otherwise it defaults to the full resolution which is way bigger than we need, and causes some significant problems:

* It allocates more memory than necessary, which is always at risk of failure.

* The lores images can be too large for the GPU to display on Pi 3 or earlier devices - this would cause an immediate crash.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>