### PR TITLE
Encoder Import Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you have installed _Picamera2_ previously using `pip`, then you should also u
 
 Thereafter, you can install _Picamera2_ _with_ all the GUI (_Qt_ and _OpenGL_) dependencies using
 ```
-sudo apt install -y python3-picamera2`
+sudo apt install -y python3-picamera2
 ```
 If you do _not_ want the GUI dependencies, use
 ```

--- a/apps/app_full.py
+++ b/apps/app_full.py
@@ -670,10 +670,10 @@ class AECTab(QWidget):
     def reset(self):
         self.aec_check.setChecked(True)
         self.awb_check.setChecked(True)
-        self.exposure_time.setValue(picam2.camera_controls["ExposureTime"][2])
-        self.analogue_gain.setValue(picam2.camera_controls["AnalogueGain"][2])
-        self.colour_gain_r.setValue(picam2.camera_controls["ColourGains"][2])
-        self.colour_gain_b.setValue(picam2.camera_controls["ColourGains"][2])
+        self.exposure_time.setValue(10000)
+        self.analogue_gain.setValue(1.0)
+        self.colour_gain_r.setValue(1.0)
+        self.colour_gain_b.setValue(1.0)
 
     @property
     def aec_dict(self):
@@ -787,15 +787,15 @@ class IMGTab(QWidget):
         }
 
     def reset(self):
-        self.ccm.setValue(picam2.camera_controls["ColourCorrectionMatrix"][2])
+        # self.ccm.setValue(picam2.camera_controls["ColourCorrectionMatrix"][2])
         self.saturation.setValue(picam2.camera_controls["Saturation"][2], emit=True)
         self.contrast.setValue(picam2.camera_controls["Contrast"][2], emit=True)
         self.sharpness.setValue(picam2.camera_controls["Sharpness"][2], emit=True)
         self.brightness.setValue(picam2.camera_controls["Brightness"][2], emit=True)
 
     def img_update(self):
-        self.ccm.setMinimum(picam2.camera_controls["ColourCorrectionMatrix"][0])
-        self.ccm.setMaximum(picam2.camera_controls["ColourCorrectionMatrix"][1])
+        # self.ccm.setMinimum(picam2.camera_controls["ColourCorrectionMatrix"][0])
+        # self.ccm.setMaximum(picam2.camera_controls["ColourCorrectionMatrix"][1])
         self.saturation.setMinimum(picam2.camera_controls["Saturation"][0])
         # self.saturation.setMaximum(picam2.camera_controls["Saturation"][1])
         self.saturation.setMaximum(6.0)
@@ -1220,5 +1220,6 @@ layout_h.addWidget(tabs)
 window.resize(1600, 600)
 window.setLayout(layout_h)
 
-window.show()
-app.exec()
+if __name__ == "__main__":
+    window.show()
+    app.exec()

--- a/apps/app_full.py
+++ b/apps/app_full.py
@@ -61,7 +61,10 @@ def post_callback(request):
 # Set up camera and application
 picam2 = Picamera2()
 picam2.post_callback = post_callback
-still_kwargs = {"lores": {}, "display": "lores", "encode": "lores", "buffer_count": 1}
+lores_size = picam2.sensor_resolution
+while lores_size[0] > 1600:
+    lores_size = (lores_size[0] // 2 & ~1, lores_size[1] // 2 & ~1)
+still_kwargs = {"lores": {"size": lores_size}, "display": "lores", "encode": "lores", "buffer_count": 1}
 picam2.still_configuration = picam2.create_still_configuration(
     **still_kwargs
 )

--- a/examples/title_bar.py
+++ b/examples/title_bar.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+
+from picamera2 import Picamera2
+import time
+
+picam2 = Picamera2()
+picam2.start(show_preview=True)
+time.sleep(0.5)
+
+# Or you could do this before starting the camera.
+picam2.title_fields = ["ExposureTime", "AnalogueGain", "DigitalGain"]
+time.sleep(2)
+
+# And you can change it too.
+picam2.title_fields = ["ColourTemperature", "ColourGains"]
+time.sleep(2)

--- a/picamera2/controls.py
+++ b/picamera2/controls.py
@@ -30,7 +30,7 @@ class Controls():
                 name = real_field[0]
                 value = real_field[1](value)
             if name not in self._picam2.camera_ctrl_info.keys():
-                raise RuntimeError(f"Control {name} is not advertied by libcamera")
+                raise RuntimeError(f"Control {name} is not advertised by libcamera")
             self._controls.append(name)
         self.__dict__[name] = value
 

--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -3,7 +3,7 @@
 from math import sqrt
 from picamera2.encoders import Quality
 from picamera2.encoders.v4l2_encoder import V4L2Encoder
-from v4l2 import *
+from v4l2 import V4L2_PIX_FMT_H264, V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, V4L2_CID_MPEG_VIDEO_REPEAT_SEQ_HEADER
 
 from picamera2.encoders.v4l2_encoder import V4L2Encoder
 

--- a/picamera2/encoders/mjpeg_encoder.py
+++ b/picamera2/encoders/mjpeg_encoder.py
@@ -3,7 +3,7 @@
 from math import sqrt
 from picamera2.encoders import Quality
 from picamera2.encoders.v4l2_encoder import V4L2Encoder
-from v4l2 import *
+from v4l2 import V4L2_PIX_FMT_MJPEG
 
 from picamera2.encoders.v4l2_encoder import V4L2Encoder
 

--- a/picamera2/encoders/v4l2_encoder.py
+++ b/picamera2/encoders/v4l2_encoder.py
@@ -1,5 +1,6 @@
 """Provide V4L2 encoding functionality"""
 
+import ctypes
 import fcntl
 import mmap
 import queue

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -8,7 +8,7 @@ import selectors
 import tempfile
 import threading
 from enum import Enum
-from typing import List
+from typing import List, Tuple, Any, Dict, Optional
 import time
 from concurrent.futures import Future
 from functools import partial
@@ -187,7 +187,7 @@ class Picamera2:
         self._encoder = None
         self.pre_callback = None
         self.post_callback = None
-        self.completed_requests = []
+        self.completed_requests: List[CompletedRequest] = []
         self.lock = threading.Lock()  # protects the functions and completed_requests fields
         self.have_event_loop = False
         self.camera_properties_ = {}
@@ -195,7 +195,7 @@ class Picamera2:
         self.sensor_modes_ = None
 
     @property
-    def preview_configuration(self):
+    def preview_configuration(self) -> CameraConfiguration:
         return self.preview_configuration_
 
     @preview_configuration.setter
@@ -203,7 +203,7 @@ class Picamera2:
         self.preview_configuration_ = CameraConfiguration(value, self)
 
     @property
-    def still_configuration(self):
+    def still_configuration(self) -> CameraConfiguration:
         return self.still_configuration_
 
     @still_configuration.setter
@@ -211,7 +211,7 @@ class Picamera2:
         self.still_configuration_ = CameraConfiguration(value, self)
 
     @property
-    def video_configuration(self):
+    def video_configuration(self) -> CameraConfiguration:
         return self.video_configuration_
 
     @video_configuration.setter
@@ -500,7 +500,7 @@ class Picamera2:
 
     _raw_stream_ignore_list = ["bit_depth", "crop_limits", "exposure_limits", "fps", "unpacked"]
 
-    def create_preview_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Sycc(), buffer_count=4, controls={}, display="main", encode="main"):
+    def create_preview_configuration(self, main={}, lores=None, raw=None, transform=libcamera.Transform(), colour_space=libcamera.ColorSpace.Sycc(), buffer_count=4, controls={}, display="main", encode="main") -> dict:
         """Make a configuration suitable for camera preview."""
         if self.camera is None:
             raise RuntimeError("Camera not opened")
@@ -582,6 +582,10 @@ class Picamera2:
         return config
 
     def check_stream_config(self, stream_config, name) -> None:
+        """Check the configuration of the passed in config.
+
+        Raises RuntimeError if the configuration is invalid.
+        """
         # Check the parameters for a single stream.
         if type(stream_config) is not dict:
             raise RuntimeError(name + " stream should be a dictionary")
@@ -1068,7 +1072,7 @@ class Picamera2:
         with self.lock:
             self._dispatch_functions(functions, signal_function)
 
-    def capture_file_(self, file_output, name, format=None):
+    def capture_file_(self, file_output, name: str, format=None) -> dict:
         request = self.completed_requests.pop(0)
         if name == "raw" and self.is_raw(self.camera_config["raw"]["format"]):
             request.save_dng(file_output)
@@ -1099,8 +1103,17 @@ class Picamera2:
         if wait:
             return self.wait()
 
-    def capture_file(self, file_output, name="main", format=None, wait=None, signal_function=None):
-        """Capture an image to a file in the current camera mode."""
+    def capture_file(
+            self,
+            file_output,
+            name: str = "main",
+            format=None,
+            wait=None,
+            signal_function=None) -> dict:
+        """Capture an image to a file in the current camera mode.
+
+        Return the metadata for the frame captured.
+        """
         return self._execute_or_dispatch(partial(self.capture_file_, file_output, name, format=format),
                                          wait, signal_function)
 
@@ -1186,7 +1199,7 @@ class Picamera2:
         """Make a 1d numpy array from the next frame in the named stream."""
         return self._execute_or_dispatch(partial(self.capture_buffer_, name), wait, signal_function)
 
-    def capture_buffers_and_metadata_(self, names):
+    def capture_buffers_and_metadata_(self, names) -> Tuple[List[np.ndarray], dict]:
         request = self.completed_requests.pop(0)
         result = ([request.make_buffer(name) for name in names], request.get_metadata())
         request.release()
@@ -1244,7 +1257,7 @@ class Picamera2:
         """Make a 2d image from the next frame in the named stream."""
         return self._execute_or_dispatch(partial(self.capture_array_, name), wait, signal_function)
 
-    def capture_arrays_and_metadata_(self, names):
+    def capture_arrays_and_metadata_(self, names) -> Tuple[List[np.ndarray], Dict[str, Any]]:
         request = self.completed_requests.pop(0)
         result = ([request.make_array(name) for name in names], request.get_metadata())
         request.release()
@@ -1290,7 +1303,7 @@ class Picamera2:
         if wait:
             return self.wait()
 
-    def capture_image_(self, name):
+    def capture_image_(self, name: str) -> Image:
         """Capture image
 
         :param name: Stream name
@@ -1301,7 +1314,7 @@ class Picamera2:
         request.release()
         return (True, result)
 
-    def capture_image(self, name="main", wait=None, signal_function=None) -> Image:
+    def capture_image(self, name: str = "main", wait: bool = None, signal_function=None) -> Image:
         """Make a PIL image from the next frame in the named stream.
 
         :param name: Stream name, defaults to "main"
@@ -1315,7 +1328,7 @@ class Picamera2:
         """
         return self._execute_or_dispatch(partial(self.capture_image_, name), wait, signal_function)
 
-    def switch_mode_and_capture_image(self, camera_config, name="main", wait=None, signal_function=None):
+    def switch_mode_and_capture_image(self, camera_config, name: str = "main", wait: bool = None, signal_function=None) -> Image:
         """Switch the camera into a new (capture) mode, capture the image, then return
         back to the initial camera mode.
         """
@@ -1323,7 +1336,7 @@ class Picamera2:
             wait = signal_function is None
         preview_config = self.camera_config
 
-        def capture_image_and_switch_back_(self, preview_config, name):
+        def capture_image_and_switch_back_(self, preview_config, name) -> Image:
             _, result = self.capture_image_(name)
             self.switch_mode_(preview_config)
             return (True, result)
@@ -1367,7 +1380,7 @@ class Picamera2:
         self.encoder._stop()
 
     @property
-    def encoder(self):
+    def encoder(self) -> Optional[Encoder]:
         """Extract current Encoder object
 
         :return: Encoder
@@ -1427,7 +1440,7 @@ class Picamera2:
                 raise RuntimeError("Overlay must be a 4-channel image")
         self._preview.set_overlay(overlay)
 
-    def start_and_capture_files(self, name="image{:03d}.jpg", initial_delay=1, preview_mode="preview", capture_mode="still", num_files=1, delay=1, show_preview=True):
+    def start_and_capture_files(self, name: str = "image{:03d}.jpg", initial_delay=1, preview_mode="preview", capture_mode="still", num_files=1, delay=1, show_preview=True):
         """
         This function makes capturing multiple images more conenient, but should only be used in
         command line line applications (not from a Qt application, for example). If will configure

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -384,7 +384,12 @@ class Picamera2:
         self.sensor_modes_ = []
 
         for pix in raw_formats.pixel_formats:
-            fmt = SensorFormat(str(pix))
+            name = str(pix)
+            if not self.is_raw(name):
+                # Not a raw sensor so we can't deduce much about it. Quote the name and carry on.
+                self.sensor_modes_.append({"format": name})
+                continue
+            fmt = SensorFormat(name)
             all_format = {}
             all_format["format"] = fmt
             all_format["unpacked"] = fmt.unpacked
@@ -625,7 +630,8 @@ class Picamera2:
             if not self.is_raw(format):
                 raise RuntimeError("Unrecognised raw format " + format)
         else:
-            if not self.is_YUV(format) and not self.is_RGB(format):
+            # Allow "MJPEG" as we have some support for USB MJPEG-type cameras.
+            if not self.is_YUV(format) and not self.is_RGB(format) and format != 'MJPEG':
                 raise RuntimeError("Bad format " + format + " in stream " + name)
         size = stream_config["size"]
         if type(size) is not tuple or len(size) != 2:

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -331,7 +331,6 @@ class Picamera2:
 
         if self.camera is not None:
             self.__identify_camera()
-
             # Re-generate the controls list to someting easer to use.
             for k, v in self.camera.controls.items():
                 self.camera_ctrl_info[k.name] = (k, v)
@@ -534,8 +533,9 @@ class Picamera2:
             self.align_stream(lores, optimal=False)
         raw = self._make_initial_stream_config({"format": self.sensor_format, "size": main["size"]}, raw, self._raw_stream_ignore_list)
         # Let the framerate vary from 12fps to as fast as possible.
-        controls = {"NoiseReductionMode": libcamera.controls.draft.NoiseReductionModeEnum.Minimal,
-                    "FrameDurationLimits": (100, 83333)} | controls
+        if "NoiseReductionMode" in self.camera_controls and "FrameDurationLimits" in self.camera_controls:
+            controls = {"NoiseReductionMode": libcamera.controls.draft.NoiseReductionModeEnum.Minimal,
+                        "FrameDurationLimits": (100, 83333)} | controls
         config = {"use_case": "preview",
                   "transform": transform,
                   "colour_space": colour_space,
@@ -558,8 +558,9 @@ class Picamera2:
             self.align_stream(lores, optimal=False)
         raw = self._make_initial_stream_config({"format": self.sensor_format, "size": main["size"]}, raw)
         # Let the framerate span the entire possible range of the sensor.
-        controls = {"NoiseReductionMode": libcamera.controls.draft.NoiseReductionModeEnum.HighQuality,
-                    "FrameDurationLimits": (100, 1000000 * 1000)} | controls
+        if "NoiseReductionMode" in self.camera_controls and "FrameDurationLimits" in self.camera_controls:
+            controls = {"NoiseReductionMode": libcamera.controls.draft.NoiseReductionModeEnum.HighQuality,
+                        "FrameDurationLimits": (100, 1000000 * 1000)} | controls
         config = {"use_case": "still",
                   "transform": transform,
                   "colour_space": colour_space,
@@ -591,8 +592,9 @@ class Picamera2:
                 colour_space = libcamera.ColorSpace.Smpte170m()
             else:
                 colour_space = libcamera.ColorSpace.Rec709()
-        controls = {"NoiseReductionMode": libcamera.controls.draft.NoiseReductionModeEnum.Fast,
-                    "FrameDurationLimits": (33333, 33333)} | controls
+        if "NoiseReductionMode" in self.camera_controls and "FrameDurationLimits" in self.camera_controls:
+            controls = {"NoiseReductionMode": libcamera.controls.draft.NoiseReductionModeEnum.Fast,
+                        "FrameDurationLimits": (33333, 33333)} | controls
         config = {"use_case": "video",
                   "transform": transform,
                   "colour_space": colour_space,

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -80,3 +80,6 @@ class NullPreview:
         self.running = False
         self.thread.join()
         self.picam2 = None
+
+    def set_title_function(self, function):
+        pass

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -98,6 +98,7 @@ class QGlPicamera2(QWidget):
         self.current_request = None
         self.own_current = False
         self.stop_count = 0
+        self.title_function = None
         self.egl = EglState()
         if picam2.verbose_console:
             print("EGL {} {}".format(
@@ -358,6 +359,8 @@ class QGlPicamera2(QWidget):
     def handle_requests(self):
         request = self.picamera2.process_requests()
         if request:
+            if self.title_function is not None:
+                self.setWindowTitle(self.title_function(request.get_metadata()))
             if self.picamera2.display_stream_name is not None:
                 with self.lock:
                     eglMakeCurrent(self.egl.display, self.surface, self.surface, self.egl.context)

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -36,6 +36,7 @@ class QPicamera2(QGraphicsView):
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.enabled = True
+        self.title_function = None
 
         self.update_overlay_signal.connect(self.update_overlay)
         self.camera_notifier = QSocketNotifier(self.picamera2.camera_manager.event_fd,
@@ -147,6 +148,8 @@ class QPicamera2(QGraphicsView):
         if not request:
             return
 
+        if self.title_function is not None:
+            self.setWindowTitle(self.title_function(request.get_metadata()))
         camera_config = self.picamera2.camera_config
         if self.enabled and self.picamera2.display_stream_name is not None and camera_config is not None:
             stream_config = camera_config[self.picamera2.display_stream_name]

--- a/picamera2/previews/qt_previews.py
+++ b/picamera2/previews/qt_previews.py
@@ -59,6 +59,9 @@ class QtPreviewBase:
     def set_overlay(self, overlay):
         self.qpicamera2.set_overlay(overlay)
 
+    def set_title_function(self, function):
+        self.qpicamera2.title_function = function
+
 
 class QtPreview(QtPreviewBase):
     def make_picamera2_widget(self, picam2, width=640, height=480, transform=None):

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -21,9 +21,12 @@ class _MappedBuffer:
 
         # Check if the buffer is contiguous and find the total length.
         fd = self.__fb.planes[0].fd
+        planes_metadata = self.__fb.metadata.planes
         buflen = 0
-        for p in self.__fb.planes:
-            buflen = buflen + p.length
+        for p, p_metadata in zip(self.__fb.planes, planes_metadata):
+            # bytes_used is the same as p.length for regular frames, but correctly reflects
+            # the compressed image size for MJPEG cameras.
+            buflen = buflen + p_metadata.bytes_used
             if fd != p.fd:
                 raise RuntimeError('_MappedBuffer: Cannot map non-contiguous buffer!')
 

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -194,6 +194,10 @@ class Helpers:
             # efficiently. We leave any packing in there, however, as it would be easier
             # to remove that after conversion to RGB (if that's what the caller does).
             image = array.reshape((h * 3 // 2, stride))
+        elif fmt in ("YUYV", "YVYU", "UYVY", "VYUY"):
+            # These dimensions seem a bit strange, but mean that
+            # cv2.cvtColor(image, cv2.COLOR_YUV2BGR_YUYV) will convert directly to RGB.
+            image = array.reshape(h, stride // 2, 2)
         elif fmt == "MJPEG":
             image = np.array(Image.open(io.BytesIO(array)))
         elif self.picam2.is_raw(fmt):

--- a/tests/app_full.py
+++ b/tests/app_full.py
@@ -1,0 +1,1 @@
+../apps/app_full.py

--- a/tests/app_full_test.py
+++ b/tests/app_full_test.py
@@ -1,0 +1,16 @@
+import threading
+import time
+
+from app_full import app, window
+
+
+def test_func():
+    time.sleep(5)
+    app.quit()
+
+
+thread = threading.Thread(target=test_func, daemon=True)
+thread.start()
+
+window.show()
+app.exec()

--- a/tests/close_test.py
+++ b/tests/close_test.py
@@ -1,0 +1,34 @@
+from picamera2 import Picamera2
+import subprocess
+import sys
+
+# First open/close several times in this process in various ways.
+
+
+def run_camera():
+    camera = Picamera2()
+    camera.start()
+    camera.stop()
+    camera.close()
+
+
+run_camera()
+
+with Picamera2() as picam2:
+    picam2.start()
+    picam2.stop()
+
+picam2 = Picamera2()
+picam2.start()
+picam2.stop()
+picam2.close()
+
+# Check that everything is released so other processes can use the camera.
+
+program = """from picamera2 import Picamera2
+picam2 = Picamera2()
+picam2.start()"""
+print("Start camera in separate process:")
+cmd = ['python3', '-c', program]
+p = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+p.wait()

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -37,6 +37,7 @@ examples/tuning_file.py
 examples/video_with_config.py
 examples/window_offset.py
 examples/zoom.py
+tests/app_full_test.py
 tests/app_test.py
 tests/check_timestamps.py
 tests/close_test.py

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -32,6 +32,7 @@ examples/still_capture_with_config.py
 examples/still_during_video.py
 examples/switch_mode.py
 examples/switch_mode_2.py
+examples/title_bar.py
 examples/tuning_file.py
 examples/video_with_config.py
 examples/window_offset.py

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -39,6 +39,7 @@ examples/window_offset.py
 examples/zoom.py
 tests/app_test.py
 tests/check_timestamps.py
+tests/close_test.py
 tests/configurations.py
 tests/context_test.py
 tests/display_transform_null.py

--- a/tools/checkstyle.py
+++ b/tools/checkstyle.py
@@ -346,10 +346,11 @@ class StyleChecker(metaclass=ClassRegistry):
 
 
 class StyleIssue(object):
-    def __init__(self, line_number, line, msg):
+    def __init__(self, line_number, line, msg, offset=None):
         self.line_number = line_number
         self.line = line
         self.msg = msg
+        self.offset = offset
 
 
 class IncludeChecker(StyleChecker):
@@ -413,7 +414,7 @@ class Pep8Checker(StyleChecker):
 
             if line_number in line_numbers:
                 line = self.__content[line_number - 1]
-                issues.append(StyleIssue(line_number, line, msg))
+                issues.append(StyleIssue(line_number, line, msg, position))
 
         return issues
 
@@ -614,6 +615,8 @@ def check_file(top_level, commit, filename):
                   (Colours.fg(Colours.Yellow), issue.line_number, issue.msg))
             if issue.line is not None:
                 print('+%s%s' % (issue.line.rstrip(), Colours.reset()))
+                if issue.offset is not None:
+                    print(" " * (issue.offset) + "^")
 
     return len(formatted_diff) + len(issues)
 


### PR DESCRIPTION
Star imports are kinda sketchy. In this case, the `ctypes` module was getting imported through the v4l2 module...

This can lead to circular imports and other confusion. I can see what that module does not use an `__all__` block it looks like it was codegened :/