### PR TITLE
encoders import tidy.

### DIFF
--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -1,10 +1,11 @@
 """H264 encoder functionality"""
 
 from math import sqrt
-from picamera2.encoders import Quality
-from picamera2.encoders.v4l2_encoder import V4L2Encoder
-from v4l2 import *
 
+from v4l2 import (V4L2_CID_MPEG_VIDEO_H264_I_PERIOD,
+                  V4L2_CID_MPEG_VIDEO_REPEAT_SEQ_HEADER, V4L2_PIX_FMT_H264)
+
+from picamera2.encoders import Quality
 from picamera2.encoders.v4l2_encoder import V4L2Encoder
 
 

--- a/picamera2/encoders/mjpeg_encoder.py
+++ b/picamera2/encoders/mjpeg_encoder.py
@@ -1,10 +1,10 @@
 """MJPEG encoder functionality utilising V4L2"""
 
 from math import sqrt
-from picamera2.encoders import Quality
-from picamera2.encoders.v4l2_encoder import V4L2Encoder
-from v4l2 import *
 
+from v4l2 import V4L2_PIX_FMT_MJPEG
+
+from picamera2.encoders import Quality
 from picamera2.encoders.v4l2_encoder import V4L2Encoder
 
 

--- a/picamera2/encoders/v4l2_encoder.py
+++ b/picamera2/encoders/v4l2_encoder.py
@@ -1,5 +1,6 @@
 """Provide V4L2 encoding functionality"""
 
+import ctypes
 import fcntl
 import mmap
 import queue


### PR DESCRIPTION
Star imports are kinda sketchy. In this case, the `ctypes` module was getting imported through the v4l2 module...

This can lead to circular imports and other confusion. I can see what that module does not use an `__all__` block it looks like it was codegened :/