### PR TITLE
Multicam drm preview

### DIFF
--- a/tests/drm_multiple_test.py
+++ b/tests/drm_multiple_test.py
@@ -1,0 +1,24 @@
+from picamera2 import Picamera2, Preview
+import time
+
+picam2a = Picamera2(0)
+picam2a.start_preview(Preview.DRM, x=1000, y=0)
+picam2a.start()
+time.sleep(1)
+
+picam2b = Picamera2(1)
+picam2b.start_preview(Preview.DRM, x=1000, y=500)
+picam2b.start()
+time.sleep(1)
+
+picam2a.close()
+picam2a = Picamera2(0)
+picam2a.start_preview(Preview.DRM, x=0, y=0)
+picam2a.start()
+time.sleep(1)
+
+picam2b.close()
+picam2b = Picamera2(1)
+picam2b.start_preview(Preview.DRM, x=0, y=500)
+picam2b.start()
+time.sleep(1)


### PR DESCRIPTION
The first commit enables two DRM preview windows to be made when multiple cameras are available, one for each camera.

The second commit adds a simple test for this.