### PR TITLE
Global camera info

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -186,6 +186,19 @@ class Picamera2:
             return tuning[name]
         return next(algo for algo in tuning["algorithms"] if name in algo)[name]
 
+    @staticmethod
+    def global_camera_info() -> list:
+        """
+        Return Id string and Model name for all attached cameras, one dict per camera,
+        and ordered correctly by camera number. Also return the location and rotation
+        of the camera when known, as these may help distinguish which is which.
+        """
+        def describe_camera(cam):
+            info = {k.name: v for k, v in cam.properties.items() if k.name in ("Model", "Location", "Rotation")}
+            info["Id"] = cam.id
+            return info
+        return [describe_camera(cam) for cam in libcamera.CameraManager.singleton().cameras]
+
     def __init__(self, camera_num=0, verbose_console=None, tuning=None):
         """Initialise camera system and open the camera for use.
 

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -114,7 +114,7 @@ class Picamera2:
     WARNING = logging.WARNING
     ERROR = logging.ERROR
     CRITICAL = logging.CRITICAL
-    _cm = None
+    _cm = CameraManager()
 
     @staticmethod
     def set_logging(level=logging.WARN, output=sys.stderr, msg=None):
@@ -211,8 +211,6 @@ class Picamera2:
                 os.environ["LIBCAMERA_RPI_TUNING_FILE"] = tuning_file.name
         else:
             os.environ.pop("LIBCAMERA_RPI_TUNING_FILE", None)  # Use default tuning
-        if not Picamera2._cm:
-            Picamera2._cm = CameraManager()
         self.notifyme_r, self.notifyme_w = os.pipe2(os.O_NONBLOCK)
         self.notifymeread = os.fdopen(self.notifyme_r, 'rb')
         self._cm.add(camera_num, self)

--- a/tests/multicamera.py
+++ b/tests/multicamera.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+
+import time
+
+from picamera2 import Picamera2, Preview
+
+if len(Picamera2.global_camera_info()) <= 1:
+    quit()
+
+picam2a = Picamera2(0)
+picam2a.configure(picam2a.create_preview_configuration())
+picam2a.start_preview(Preview.QTGL)
+
+picam2b = Picamera2(1)
+picam2b.configure(picam2b.create_preview_configuration())
+picam2b.start_preview(Preview.QT)
+
+picam2a.start()
+picam2b.start()
+
+time.sleep(2)
+print(picam2a.capture_metadata())
+time.sleep(2)
+print(picam2b.capture_metadata())
+picam2a.capture_file("testa.jpg")
+picam2b.capture_file("testb.jpg")
+
+picam2a.stop()
+picam2b.stop()


### PR DESCRIPTION
These commits add a `global_camera_info` static method which should make it easier to find out what cameras are attached and which to use. There are actually 3 commits:

* The first just makes our CameraManager up front so it's always there. I was going to make it hang on to the "camera manager singleton" persistently but had to shelve that bit as there are still some issues down in libcamera.
* The second commit adds the `global_camera_info` method. I thought this was probably enough and it didn't require a separate "get the number of cameras" method.
* Finally there's just a very trivial test that uses the new method.