### PR TITLE
Small change to avoid QT message

### DIFF
--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -119,7 +119,7 @@ class QGlPicamera2(QWidget):
     def cleanup(self):
         with self.lock:
             self.running = False
-            del self.camera_notifier
+            self.camera_notifier.deleteLater()
             eglDestroySurface(self.egl.display, self.surface)
             self.surface = None
             # We may be hanging on to a request, return it to the camera system.

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -46,7 +46,7 @@ class QPicamera2(QGraphicsView):
     def cleanup(self):
         del self.scene
         del self.overlay
-        del self.camera_notifier
+        self.camera_notifier.deleteLater()
 
     def signal_done(self, picamera2):
         self.done_signal.emit()


### PR DESCRIPTION
Switched to using deleteLater() rather than del on QSocketNotifier to avoid:

QSocketNotifier: Invalid socket 53 and type 'Read', disabling...

Signed-off-by: Chris Richardson <christopher.richardson@raspberrypi.org>