### PR TITLE
Create `formats.py` from dangling @classmethods

### DIFF
--- a/picamera2/encoders/encoder.py
+++ b/picamera2/encoders/encoder.py
@@ -7,7 +7,7 @@ from v4l2 import *
 
 from ..outputs import Output
 from ..request import _MappedBuffer
-
+import picamera2.formats as formats
 
 class Quality(Enum):
     """Enum type to describe the quality wanted from an encoder. This may be passed
@@ -123,12 +123,7 @@ class Encoder:
             self._format = V4L2_PIX_FMT_RGBA32
         else:
             if type(self) is Encoder:
-                """Currently allow any format that is
-                passed, when Encoder used directly.
-                We can't use Picamera2.is_raw(value) etc.
-                to validate formats here, as we get a circular import
-                when trying to import Picamera2
-                """
+                formats.assert_format_valid(value)
                 self._format = value
             else:
                 raise RuntimeError("Invalid format")

--- a/picamera2/formats.py
+++ b/picamera2/formats.py
@@ -1,0 +1,42 @@
+YUV_FORMATS = set((
+    "NV21", "NV12", "YUV420", "YVU420",
+    "YVYU", "YUYV", "UYVY", "VYUY"))
+
+RGB_FORMATS = set((
+    "BGR888", "RGB888", "XBGR8888", "XRGB8888"))
+
+BAYER_FORMATS = set((
+    "SBGGR8", "SGBRG8", "SGRBG8", "SRGGB8",
+    "SBGGR10", "SGBRG10", "SGRBG10", "SRGGB10",
+    "SBGGR10_CSI2P", "SGBRG10_CSI2P", "SGRBG10_CSI2P", "SRGGB10_CSI2P",
+    "SBGGR12", "SGBRG12", "SGRBG12", "SRGGB12",
+    "SBGGR12_CSI2P", "SGBRG12_CSI2P", "SGRBG12_CSI2P", "SRGGB12_CSI2P"))
+
+MONO_FORMATS = set(("R8", "R10", "R12", "R8_CSI2P", "R10_CSI2P", "R12_CSI2P"))
+
+ALL_FORMATS = YUV_FORMATS | RGB_FORMATS | BAYER_FORMATS | MONO_FORMATS
+
+
+def is_YUV(fmt: str) -> bool:
+    return fmt in YUV_FORMATS
+
+
+def is_RGB(fmt: str) -> bool:
+    return fmt in RGB_FORMATS
+
+
+def is_Bayer(fmt: str) -> bool:
+    return fmt in BAYER_FORMATS
+
+
+def is_mono(fmt: str) -> bool:
+    return fmt in MONO_FORMATS
+
+
+def is_raw(fmt: str) -> bool:
+    return is_Bayer(fmt) or is_mono(fmt)
+
+
+def assert_format_valid(fmt: str) -> None:
+    if fmt not in ALL_FORMATS:
+        raise ValueError(f"Invalid format: {fmt}. Valid formats are: {ALL_FORMATS}")

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -9,6 +9,7 @@ from pidng.camdefs import Picamera2Camera
 from pidng.core import PICAM2DNG
 from PIL import Image
 
+import picamera2.formats as formats
 from .controls import Controls
 
 _log = logging.getLogger(__name__)
@@ -78,7 +79,7 @@ class MappedArray:
                 # efficiently. We leave any packing in there, however, as it would be easier
                 # to remove that after conversion to RGB (if that's what the caller does).
                 array = array.reshape((h * 3 // 2, stride))
-            elif self.__request.picam2.is_raw(fmt):
+            elif formats.is_raw(fmt):
                 array = array.reshape((h, stride))
             else:
                 raise RuntimeError("Format " + fmt + " not supported")
@@ -206,7 +207,7 @@ class Helpers:
             image = array.reshape(h, stride // 2, 2)
         elif fmt == "MJPEG":
             image = np.array(Image.open(io.BytesIO(array)))
-        elif self.picam2.is_raw(fmt):
+        elif formats.is_raw(fmt):
             image = array.reshape((h, stride))
         else:
             raise RuntimeError("Format " + fmt + " not supported")


### PR DESCRIPTION
These were attached to the `picamera2` object but used largely externally.

I changed the internal implementation to using `set()` primitives as membership testing is slightly faster that way.