### PR TITLE
a couple of tweaks to make run_tests more convenient

### DIFF
--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -121,20 +121,20 @@ def directoryexists(arg):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='picamera2 automated tests')
-    parser.add_argument('--dir', '-d', action='store', type=directoryexists,
+    parser.add_argument('--dir', '-d', action='store',
                         default='/home/pi/picamera2_tests', help='Folder in which to run tests')
     parser.add_argument('--picamera2-dir', '-p', action='store', type=directoryexists,
                         default='/home/pi/picamera2', help='Location of picamera2 folder')
-    parser.add_argument('--test-list-file', '-t', action='store', type=argparse.FileType('r', encoding='UTF-8'),
+    parser.add_argument('--test-list-file', '-t', action='store',
                         default='tests/test_list.txt', help='File containing list of tests to run')
-    parser.add_argument('--test-list-file-drm', '-t2', action='store', type=argparse.FileType('r', encoding='UTF-8'),
+    parser.add_argument('--test-list-file-drm', '-t2', action='store',
                         default='tests/test_list_drm.txt', help='File containing list of tests to run')
     args = parser.parse_args()
 
     dir = args.dir
     picamera2_dir = args.picamera2_dir
-    test_list_file_x = os.path.join(picamera2_dir, args.test_list_file.name)
-    test_list_file_drm = os.path.join(picamera2_dir, args.test_list_file_drm.name)
+    test_list_file_x = os.path.join(picamera2_dir, args.test_list_file)
+    test_list_file_drm = os.path.join(picamera2_dir, args.test_list_file_drm)
 
     print("dir:", dir)
     print("Picamera2 dir:", picamera2_dir)


### PR DESCRIPTION
@chrisruk Hi Chris, thanks for all the recent work you did extending run_tests!

Whenever I've got new release apt packages to try I always do a full clean OS install on a Pi and then run these tests. On this last occasion I found the script a bit less convenient so I've tweaked a couple of things:

* It makes the picamera2_tests dir for you if it doesn't exist (rather than failing). This seems a bit more helpful, especially where folks are running it for the first time.
* I've stopped it checking the test file names so early, meaning that you can run the script from anywhere. It still fails of course, but do you think the error (a FileNotFound from load_test_list) is clear enough?