### PR TITLE
Let the camera config decide whether we hold on to the last request

### DIFF
--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -85,7 +85,7 @@ class StreamConfiguration(Configuration):
 
 
 class CameraConfiguration(Configuration):
-    _ALLOWED_FIELDS = ("use_case", "buffer_count", "transform", "display", "encode", "colour_space", "controls", "main", "lores", "raw")
+    _ALLOWED_FIELDS = ("use_case", "buffer_count", "transform", "display", "encode", "colour_space", "controls", "main", "lores", "raw", "queue")
     _FIELD_CLASS_MAP = {"main": StreamConfiguration, "lores": StreamConfiguration, "raw": StreamConfiguration}
     _FORWARD_FIELDS = {"size": "main", "format": "main"}
 


### PR DESCRIPTION
A flag in the configuration determines whether the last received completed request is kept or not. When it is kept, it can be returned quickly when a new capture request occurs. Otherwise capture requests will always wait for a new frame to arrive.

By default we always enable the queue so as not to change existing behaviour unless requested. This can of course be overridden when the configuration is created using the "queue" parameter.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>