### PR TITLE
Replace the list of functions to execute by a "job" class

### DIFF
--- a/apps/app_capture2.py
+++ b/apps/app_capture2.py
@@ -29,8 +29,8 @@ def on_button_clicked():
     picam2.switch_mode_and_capture_file(cfg, "test.jpg", signal_function=qpicamera2.signal_done)
 
 
-def capture_done():
-    picam2.wait()
+def capture_done(job):
+    picam2.wait(job)
     button.setEnabled(True)
 
 

--- a/apps/app_capture_overlay.py
+++ b/apps/app_capture_overlay.py
@@ -30,7 +30,8 @@ def on_button_clicked():
     picam2.switch_mode_and_capture_file(cfg, "test.jpg", signal_function=qpicamera2.signal_done)
 
 
-def capture_done():
+def capture_done(job):
+    picam2.wait(job)
     button.setEnabled(True)
 
 

--- a/apps/app_capture_request.py
+++ b/apps/app_capture_request.py
@@ -28,9 +28,9 @@ def on_button_clicked():
     picam2.capture_request(wait=False, signal_function=qpicamera2.signal_done)
 
 
-def capture_done():
+def capture_done(job):
     # Here's the request we captured. But we must always release it when we're done with it!
-    request = picam2.wait()
+    request = picam2.wait(job)
     print("Request:", request)
     request.release()
     button.setEnabled(True)

--- a/apps/app_full.py
+++ b/apps/app_full.py
@@ -186,11 +186,11 @@ def on_mode_change(i):
         pic_tab.apply_settings()
 
 
-def capture_done():
+def capture_done(job):
     # Here's the request we captured. But we must always release it when we're done with it!
     if not pic_tab.hdr.isChecked():
         # Save the normal image
-        request = picam2.wait()
+        request = picam2.wait(job)
         if pic_tab.filetype.currentText() == "raw":
             request.save_dng(
                 f"{pic_tab.filename.text() if pic_tab.filename.text() else 'test'}.dng"
@@ -207,7 +207,7 @@ def capture_done():
     else:
         # HDR Capture
         global hdr_imgs
-        request = picam2.wait()
+        request = picam2.wait(job)
         new_img = request.make_array("main")
         new_cv_img = cv2.cvtColor(new_img, cv2.COLOR_RGB2BGR)
         metadata = request.get_metadata()

--- a/picamera2/job.py
+++ b/picamera2/job.py
@@ -1,0 +1,63 @@
+from concurrent.futures import Future
+
+
+class Job:
+    """
+    A Job is an operation that can be delegated to the camera event loop to
+    perform, such as capturing and returning an image. Most jobs only do a single
+    thing, like copying out a numpy array, and so consist of a single function
+    that we pass to do this.
+
+    But some jobs may take several frames to complete, for example if they involve
+    mode switches, or waiting for certain controls to take effect. Here we need
+    to submit a list of functions to perform, and as each function, representing
+    a stage of the job, completes, then we will move on to the next function in
+    the list when the next frame arrives.
+
+    Jobs are normally created by the Picamera2.dispatch_functions method, though
+    most common operations have dedicated methods to do this, such as
+    Picamera2.switch_mode_and_capture_array.
+    """
+
+    def __init__(self, functions, signal_function=None):
+        self._functions = functions
+        self._future = Future()
+        self._future.set_running_or_notify_cancel()
+        if signal_function is not None:
+            self._future.add_done_callback(signal_function)
+
+        # I wonder if there is any useful information we could collect, number
+        # of frames it took for things to finish, maybe intermediate results...
+        self.calls = 0
+
+    def execute(self):
+        """Try to execute this Job. It will return True if it finishes,
+        or False if it needs to be tried again."""
+        assert self._functions, "Job already completed!"
+
+        try:
+            # Each function making up the Job returns two things: whether it's
+            # "done", in which case we pop it off the list so that the function
+            # in the list will run with the next frame (otherwise we leave it there
+            # to try again next time). Secondly, it returns a value that counts
+            # as its "result" once it completes.
+            done, result = self._functions[0]()
+            self.calls += 1
+            if done:
+                self._functions.pop(0)
+
+                # When no functions are left, the entire job is complete.
+                if not self._functions:
+                    self._future.set_result(result)
+
+        except Exception as e:
+            self._future.set_exception(e)
+            self._functions = []
+
+        return not self._functions
+
+    def get_result(self):
+        """This fetches the 'final result' of the job (being given by the return
+        value of the last function executed). It will block if necessary for the
+        job to complete."""
+        return self._future.result()

--- a/picamera2/job.py
+++ b/picamera2/job.py
@@ -24,7 +24,7 @@ class Job:
         self._future = Future()
         self._future.set_running_or_notify_cancel()
         if signal_function is not None:
-            self._future.add_done_callback(signal_function)
+            self._future.add_done_callback(lambda f: signal_function(self))
 
         # I wonder if there is any useful information we could collect, number
         # of frames it took for things to finish, maybe intermediate results...

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -77,7 +77,7 @@ class EglState:
 
 
 class QGlPicamera2(QWidget):
-    done_signal = pyqtSignal()
+    done_signal = pyqtSignal(object)
 
     def __init__(self, picam2, parent=None, width=640, height=480, bg_colour=(20, 20, 20), keep_ar=True, transform=None):
         super().__init__(parent=parent)
@@ -127,8 +127,8 @@ class QGlPicamera2(QWidget):
                 self.current_request.release()
             self.current_request = None
 
-    def signal_done(self, picamera2):
-        self.done_signal.emit()
+    def signal_done(self, job):
+        self.done_signal.emit(job)
 
     def paintEngine(self):
         return None

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 class QPicamera2(QGraphicsView):
-    done_signal = pyqtSignal()
+    done_signal = pyqtSignal(object)
     update_overlay_signal = pyqtSignal(object)
 
     def __init__(self, picam2, parent=None, width=640, height=480, bg_colour=(20, 20, 20), keep_ar=True, transform=None):
@@ -48,8 +48,8 @@ class QPicamera2(QGraphicsView):
         del self.overlay
         self.camera_notifier.deleteLater()
 
-    def signal_done(self, picamera2):
-        self.done_signal.emit()
+    def signal_done(self, job):
+        self.done_signal.emit(job)
 
     def image_dimensions(self):
         # The dimensions of the camera images we're displaying.

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -31,8 +31,8 @@ def on_button_clicked():
     picam2.switch_mode_and_capture_file(cfg, "test.jpg", signal_function=qpicamera2.signal_done)
 
 
-def capture_done():
-    picam2.wait()
+def capture_done(job):
+    picam2.wait(job)
     button.setEnabled(True)
 
 

--- a/tests/async_test.py
+++ b/tests/async_test.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+
+from picamera2 import Picamera2
+from threading import Thread
+import time
+
+picam2 = Picamera2()
+config = picam2.create_preview_configuration(queue=False)
+picam2.configure(config)
+picam2.start()
+abort = False
+
+
+def thread_func(delay):
+    n = 0
+    while not abort:
+        picam2.capture_array()
+        n += 1
+        time.sleep(delay)
+    print("Thread received", n, "frames")
+
+
+delays = [0.1, 0.07, 0.15]
+
+threads = [Thread(target=thread_func, args=(d, )) for d in delays]
+
+for thread in threads:
+    thread.start()
+
+time.sleep(5)
+
+jobs = []
+for i in range(10):
+    jobs.append(picam2.capture_metadata(wait=False))
+    time.sleep(0.01)
+times = [job.get_result()["SensorTimestamp"] for job in jobs]
+diffs = [(t1 - t0) // 1000 for t0, t1 in zip(times[:-1], times[1:])]
+print(diffs)
+if any(d < 0 for d in diffs):
+    print("Error: unexpected frame times")
+
+time.sleep(5)
+
+abort = True
+for thread in threads:
+    thread.join()
+
+picam2.stop()

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -39,6 +39,7 @@ examples/window_offset.py
 examples/zoom.py
 tests/app_full_test.py
 tests/app_test.py
+tests/async_test.py
 tests/check_timestamps.py
 tests/close_test.py
 tests/close_test_multiple.py


### PR DESCRIPTION
There are 5 commits here but I think they leave things tidier and better. I've tried to organise the changes and commit messages so that it's reasonably clear what's happened, and the tests should be fully working after each commit. They are:

1. This is just a simple code tidy in this general area, no functional changes.
2. Replaces the list of functions that get executed by a "job". Again there is no functional change here, but wrapping up all the functions into a single "job" makes things tidier, and will help subsequent commits.
3. Here we update the `wait()` method. You now have to say what "job" you're waiting for. This is a breaking change but this commit also fixes up all the Qt examples that are affected. In particular, we have to pass the "job" through the Qt signals to the application's callback functions.
4. With all the functions now in a single "job", it's easy to extend the single job to a list, so that you can have several at once.
5. Adds a test for these changes.