### PR TITLE
Make start_encoder parameters more like start_recording

### DIFF
--- a/apps/app_full.py
+++ b/apps/app_full.py
@@ -144,8 +144,7 @@ def on_vid_button_clicked():
             output = FileOutput(
                 f"{vid_tab.filename.text() if vid_tab.filename.text() else 'test'}.{vid_tab.filetype.currentText()}"
             )
-        encoder.output = output
-        picam2.start_encoder(encoder, vid_tab.quality)
+        picam2.start_encoder(encoder, output, vid_tab.quality)
         rec_button.setText("Stop recording")
         recording = True
     else:

--- a/apps/app_recording.py
+++ b/apps/app_recording.py
@@ -25,8 +25,8 @@ def on_button_clicked():
     global recording
     if not recording:
         encoder = H264Encoder(10000000)
-        encoder.output = FileOutput("test.h264")
-        picam2.start_encoder(encoder)
+        output = FileOutput("test.h264")
+        picam2.start_encoder(encoder, output)
         button.setText("Stop recording")
         recording = True
     else:

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1420,7 +1420,7 @@ class Picamera2:
                      partial(capture_image_and_switch_back_, self, preview_config, name)]
         self.dispatch_functions(functions, wait, signal_function)
 
-    def start_encoder(self, encoder=None, quality=Quality.MEDIUM) -> None:
+    def start_encoder(self, encoder=None, output=None, pts=None, quality=Quality.MEDIUM) -> None:
         """Start encoder
 
         :param encoder: Sets encoder or uses existing, defaults to None
@@ -1429,6 +1429,10 @@ class Picamera2:
         """
         if encoder is not None:
             self.encoder = encoder
+        if output is not None:
+            if isinstance(output, str):
+                output = FileOutput(output, pts=pts)
+            encoder.output = output
         streams = self.camera_configuration()
         if self.encoder is None:
             raise RuntimeError("No encoder specified")
@@ -1487,10 +1491,7 @@ class Picamera2:
             config = "video"
         if config is not None:
             self.configure(config)
-        if isinstance(output, str):
-            output = FileOutput(output, pts=pts)
-        encoder.output = output
-        self.start_encoder(encoder, quality)
+        self.start_encoder(encoder, output, pts=pts, quality=quality)
         self.start()
 
     def stop_recording(self) -> None:
@@ -1645,8 +1646,7 @@ class Picamera2:
                     output = FileOutput(output)
         if encoder is None:
             encoder = H264Encoder()
-        encoder.output = output
-        self.start_encoder(encoder, quality)
+        self.start_encoder(encoder, output, quality)
         self.start(show_preview=show_preview)
         if duration:
             time.sleep(duration)


### PR DESCRIPTION
Both now take an encoder and an output, making them a bit more consistent and it's easier to remember how to use them.

It does actually break just a few existing usages of the API, but they're easily updated (as has been done as part of this commit).

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>