### PR TITLE
Fix Qt problems closing preview windows with the X button (version 2)

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -536,8 +536,8 @@ class Picamera2:
             # Assume it's already a preview object.
             pass
 
+        # The preview windows call the attach_preview method.
         preview.start(self)
-        self.attach_preview(preview)
 
     def detach_preview(self) -> None:
         self._preview = None
@@ -552,8 +552,8 @@ class Picamera2:
             raise RuntimeError("No preview specified.")
 
         try:
+            # The preview windows call the detach_preview method.
             self._preview.stop()
-            self.detach_preview()
         except Exception:
             raise RuntimeError("Unable to stop preview.")
 

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -494,6 +494,10 @@ class Picamera2:
                 self.sensor_modes_.append(cam_mode)
         return self.sensor_modes_
 
+    def attach_preview(self, preview) -> None:
+        self._preview = preview
+        self.have_event_loop = True
+
     def start_preview(self, preview=False, **kwargs) -> None:
         """
         Start the given preview which drives the camera processing.
@@ -533,8 +537,11 @@ class Picamera2:
             pass
 
         preview.start(self)
-        self._preview = preview
-        self.have_event_loop = True
+        self.attach_preview(preview)
+
+    def detach_preview(self) -> None:
+        self._preview = None
+        self.have_event_loop = False
 
     def stop_preview(self) -> None:
         """Stop preview
@@ -546,8 +553,7 @@ class Picamera2:
 
         try:
             self._preview.stop()
-            self._preview = None
-            self.have_event_loop = False
+            self.detach_preview()
         except Exception:
             raise RuntimeError("Unable to stop preview.")
 

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -56,6 +56,7 @@ class NullPreview:
         :type picam2: Picamera2
         """
         self.picam2 = picam2
+        picam2.attach_preview(self)
         self._started.clear()
         self._abort.clear()
         self.thread = threading.Thread(target=self.thread_func, args=(picam2,))
@@ -89,6 +90,7 @@ class NullPreview:
         """Stop preview"""
         self._abort.set()
         self.thread.join()
+        self.picam2.detach_preview()
         self.picam2 = None
 
     def set_title_function(self, function):

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -130,6 +130,9 @@ class QGlPicamera2(QWidget):
             if self.preview_window is not None:
                 self.preview_window.qpicamera2 = None
 
+    def closeEvent(self, event):
+        self.cleanup()
+
     def signal_done(self, job):
         self.done_signal.emit(job)
 

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -16,10 +16,12 @@ class QPicamera2(QGraphicsView):
     done_signal = pyqtSignal(object)
     update_overlay_signal = pyqtSignal(object)
 
-    def __init__(self, picam2, parent=None, width=640, height=480, bg_colour=(20, 20, 20), keep_ar=True, transform=None):
+    def __init__(self, picam2, parent=None, width=640, height=480, bg_colour=(20, 20, 20),
+                 keep_ar=True, transform=None, preview_window=None):
         super().__init__(parent=parent)
         self.picamera2 = picam2
-        picam2.have_event_loop = True
+        picam2.attach_preview(preview_window)
+        self.preview_window = preview_window
         self.keep_ar = keep_ar
         self.transform = Transform() if transform is None else transform
         self.image_size = None
@@ -46,6 +48,12 @@ class QPicamera2(QGraphicsView):
         del self.scene
         del self.overlay
         self.camera_notifier.deleteLater()
+        # We have to tell both the preview window and the Picamera2 object that we have
+        # disappeared.
+        if self.picamera2 is not None:
+            self.picamera2.detach_preview()
+        if self.preview_window is not None:
+            self.preview_window.qpicamera2 = None
 
     def signal_done(self, job):
         self.done_signal.emit(job)

--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -55,6 +55,9 @@ class QPicamera2(QGraphicsView):
         if self.preview_window is not None:
             self.preview_window.qpicamera2 = None
 
+    def closeEvent(self, event):
+        self.cleanup()
+
     def signal_done(self, job):
         self.done_signal.emit(job)
 

--- a/picamera2/previews/qt_previews.py
+++ b/picamera2/previews/qt_previews.py
@@ -105,8 +105,6 @@ class QtPreviewBase:
             retq = Queue()
             QtPreviewBase.previewcreateq.put((Command.DELETE, retq, (self, self.qpicamera2)))
             retq.get()
-            del self.qpicamera2
-            self.qpicamera2 = None
 
     def fin(self):
         if QtPreviewBase.thread:
@@ -124,7 +122,7 @@ class QtPreviewBase:
 class QtPreview(QtPreviewBase):
     def make_picamera2_widget(self, picam2, width=640, height=480, transform=None):
         from picamera2.previews.qt import QPicamera2
-        return QPicamera2(picam2, width=self.width, height=self.height, transform=self.transform)
+        return QPicamera2(picam2, width=self.width, height=self.height, transform=self.transform, preview_window=self)
 
     def get_title(self):
         return "QtPreview"
@@ -133,7 +131,7 @@ class QtPreview(QtPreviewBase):
 class QtGlPreview(QtPreviewBase):
     def make_picamera2_widget(self, picam2, width=640, height=480, transform=None):
         from picamera2.previews.qt import QGlPicamera2
-        return QGlPicamera2(picam2, width=self.width, height=self.height, transform=self.transform)
+        return QGlPicamera2(picam2, width=self.width, height=self.height, transform=self.transform, preview_window=self)
 
     def get_title(self):
         return "QtGlPreview"

--- a/picamera2/previews/qt_previews.py
+++ b/picamera2/previews/qt_previews.py
@@ -53,6 +53,13 @@ class QtPreviewBase:
                 self.app = app
 
             def run(self):
+                from PyQt5.QtGui import QGuiApplication
+
+                # This ensures the Qt app never quits when we click the X on the window. It means
+                # that after closing the last preview in this way, the Qt app is still running and
+                # you can create new previews.
+                QGuiApplication.setQuitOnLastWindowClosed(False)
+
                 while True:
                     cmd, retq, tup = self.previewcreateq.get()
                     if cmd == Command.CREATE:

--- a/picamera2/previews/qt_previews.py
+++ b/picamera2/previews/qt_previews.py
@@ -76,8 +76,8 @@ class QtPreviewBase:
         self.event.set()
         atexit.register(self.fin)
         app.exec()
-        atexit.unregister(self.fin)
         monitor.wait()
+        atexit.unregister(self.fin)
         del app
         # Again, all necessary to keep Qt quiet.
 

--- a/tests/preview_start_stop.py
+++ b/tests/preview_start_stop.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import time
+
+from picamera2 import Picamera2, Preview
+
+
+def click_close_button():
+    # Nasty hack just for testing, emulate clicking the window close button
+    picam2._preview.qpicamera2.close()
+
+
+picam2 = Picamera2()
+
+picam2.start_preview(Preview.QTGL)
+time.sleep(1)
+click_close_button()
+time.sleep(1)
+
+picam2.start_preview(Preview.QTGL)
+time.sleep(1)
+click_close_button()
+time.sleep(1)
+
+picam2.start_preview(Preview.QT)
+time.sleep(1)
+click_close_button()
+time.sleep(1)
+
+picam2.start_preview(Preview.QT)
+time.sleep(1)
+click_close_button()
+time.sleep(1)
+
+picam2.start_preview(Preview.QTGL)
+picam2.start()
+time.sleep(2)
+click_close_button()
+
+picam2.stop()

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -55,4 +55,5 @@ tests/multicamera.py
 tests/multicamera_2.py
 tests/preview_cycle_test.py
 tests/preview_location_test.py
+tests/preview_start_stop.py
 tests/qt_gl_preview_test.py


### PR DESCRIPTION
This is an alternative version of https://github.com/raspberrypi/picamera2/pull/445.

In some respects I've changed a lot more in this version, though hopefully things are left in a slightly better state. There are 6 commits:

1. The first adds attach_preview and detach_preview methods that the Picamera2 object uses.
2. Responsibility for calling these is moved to the previews, not the Picamera2 object. That's because the Qt previews can be closed "spontaneously" and will therefore need this code path - so I've changed it always to work like this.
3. Now we can add closeEvent handling so that the cleanup happens when a Qt window disappears spontaneously.
4. This fixes the problem where you couldn't create a new preview after one closed "spontaneously".
5. Mostly cosmetic, but I removed the "asynchronous" property because it's only used once. The commit message documents what happens when previews are started/stopped, which is now better defined.
6. Add a test for "spontaneous" closing of Qt previews.

TBH, I find the whole Qt thing, with the difficulties caused by running everything in one thread, which isn't the main thread, with multiple windows, really quite nasty. On the other hand, at least the processes involved in starting and stopping them is clearer now so that, given how much we've learnt, there's always the possibility that we could do a nicer version in the future at some point.