### PR TITLE
Support for "old" or "stale" requests

### DIFF
--- a/examples/capture_old_request.py
+++ b/examples/capture_old_request.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+# This captures a request but then switches the camera to a different mode.
+# This now "old" request can still be used.
+
+import time
+
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+capture_config = picam2.create_still_configuration()
+picam2.start(show_preview=True)
+
+time.sleep(1)
+
+request = picam2.switch_mode_and_capture_request(capture_config)
+
+# Preview should be running again...
+time.sleep(1)
+
+# But we can still save the request. Don't forget to release it once you're done!
+request.save("main", "test.jpg")
+request.release()
+
+picam2.stop()

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1225,6 +1225,24 @@ class Picamera2:
                      partial(capture_and_switch_back_, self, file_output, preview_config, format)]
         return self.dispatch_functions(functions, wait, signal_function)
 
+    def switch_mode_and_capture_request(self, camera_config, wait=None, signal_function=None):
+        """Switch the camera into a new (capture) mode and capture a request, then switch back.
+
+        Applications should use this with care because it may increase the risk of CMA heap
+        fragmentation. It may be preferable to use switch_mode_capture_request_and_stop and to
+        release the request before restarting the original camera mode.
+        """
+        preview_config = self.camera_config
+
+        def capture_and_switch_back_(self, preview_config):
+            _, result = self.capture_request_()
+            self.switch_mode_(preview_config)
+            return (True, result)
+
+        functions = [partial(self.switch_mode_, camera_config),
+                     partial(capture_and_switch_back_, self, preview_config)]
+        return self.dispatch_functions(functions, wait, signal_function)
+
     def capture_request_(self):
         # The "use" of this request is transferred from the completed_requests list to the caller.
         return (True, self.completed_requests.pop(0))

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -27,6 +27,7 @@ from .controls import Controls
 from .job import Job
 from .request import CompletedRequest, Helpers
 from .sensor_format import SensorFormat
+from .utils import convert_from_libcamera_type
 
 STILL = libcamera.StreamRole.StillCapture
 RAW = libcamera.StreamRole.Raw
@@ -386,14 +387,6 @@ class Picamera2:
         _log.debug(f"Resources now free: {self}")
         self.close()
 
-    @staticmethod
-    def _convert_from_libcamera_type(value):
-        if isinstance(value, libcamera.Rectangle):
-            value = (value.x, value.y, value.width, value.height)
-        elif isinstance(value, libcamera.Size):
-            value = (value.width, value.height)
-        return value
-
     def _grab_camera(self, idx):
         if isinstance(idx, str):
             try:
@@ -427,7 +420,7 @@ class Picamera2:
 
         # Re-generate the properties list to someting easer to use.
         for k, v in self.camera.properties.items():
-            self.camera_properties_[k.name] = self._convert_from_libcamera_type(v)
+            self.camera_properties_[k.name] = convert_from_libcamera_type(v)
 
         # The next two lines could be placed elsewhere?
         self.sensor_resolution = self.camera_properties_["PixelArraySize"]
@@ -929,7 +922,7 @@ class Picamera2:
         for k, v in self.camera.controls.items():
             self.camera_ctrl_info[k.name] = (k, v)
         for k, v in self.camera.properties.items():
-            self.camera_properties_[k.name] = self._convert_from_libcamera_type(v)
+            self.camera_properties_[k.name] = convert_from_libcamera_type(v)
 
         # Record which libcamera stream goes with which of our names.
         self.stream_map = {"main": libcamera_config.at(0).stream}

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -12,6 +12,7 @@ from PIL import Image
 import picamera2.formats as formats
 
 from .controls import Controls
+from .utils import convert_from_libcamera_type
 
 _log = logging.getLogger(__name__)
 
@@ -145,7 +146,7 @@ class CompletedRequest:
         """Fetch the metadata corresponding to this completed request."""
         metadata = {}
         for k, v in self.request.metadata.items():
-            metadata[k.name] = self.picam2._convert_from_libcamera_type(v)
+            metadata[k.name] = convert_from_libcamera_type(v)
         return metadata
 
     def make_array(self, name):

--- a/picamera2/utils.py
+++ b/picamera2/utils.py
@@ -1,0 +1,9 @@
+from libcamera import Rectangle, Size
+
+
+def convert_from_libcamera_type(value):
+    if isinstance(value, Rectangle):
+        value = (value.x, value.y, value.width, value.height)
+    elif isinstance(value, Size):
+        value = (value.width, value.height)
+    return value

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -6,6 +6,7 @@ examples/capture_full_res.py
 examples/capture_headless.py
 examples/capture_helpers.py
 examples/capture_mjpeg.py
+examples/capture_old_request.py
 examples/capture_png.py
 examples/capture_to_buffer.py
 examples/capture_video.py


### PR DESCRIPTION
By these I mean requests that the user holds on to even though the camera is subsequently stopped and reconfigured. The memory is actually held on to by the kernel and so the request can still be used so long as it stores its own proper configuration.

Now that this is supported I've added a `switch_mode_and_capture_request` method, as this is now a useful thing, along with a simple example.

Note that this does carry an increased risk of fragmenting/filling the CMA heap and must therefore be used carefully. (Though there are some libcamera updates in the works which will reduce our CMA consumption.)