### PR TITLE
Tidy and event loop updates

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1103,11 +1103,11 @@ class Picamera2:
 
             # See if we have a job to do. When executed, if it returns True then it's done and
             # we can discard it. Otherwise it remains here to be tried again next time.
-            finished_job = None
-            if self._job_list:
+            finished_jobs = []
+            while self._job_list and self.completed_requests:
                 _log.debug(f"Execute job: {self._job_list[0]}")
                 if self._job_list[0].execute():
-                    finished_job = self._job_list.pop(0)
+                    finished_jobs.append(self._job_list.pop(0))
 
             if self.encode_stream_name in self.stream_map:
                 stream = self.stream_map[self.encode_stream_name]
@@ -1134,8 +1134,8 @@ class Picamera2:
             display.render_request(display_request)
         display_request.release()
 
-        if finished_job:
-            finished_job.signal()
+        for job in finished_jobs:
+            job.signal()
 
     def wait(self, job):
         """Wait for the given job to finish (if necessary) and return its final result.

--- a/picamera2/previews/null_preview.py
+++ b/picamera2/previews/null_preview.py
@@ -71,6 +71,10 @@ class NullPreview:
         """
         # This only exists so as to have the same interface as other preview windows.
 
+    def render_request(self, completed_request):
+        """Draw the camera image. For the NullPreview, there is nothing to do."""
+        pass
+
     def handle_request(self, picam2):
         """Handle requests
 
@@ -78,13 +82,10 @@ class NullPreview:
         :type picam2: Picamera2
         """
         try:
-            completed_request = picam2.process_requests()
+            picam2.process_requests(self)
         except Exception as e:
             _log.exception("Exception during process_requests()", exc_info=e)
             raise
-
-        if completed_request:
-            completed_request.release()
 
     def stop(self):
         """Stop preview"""

--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -363,35 +363,26 @@ class QGlPicamera2(QWidget):
 
         eglSwapBuffers(self.egl.display, self.surface)
 
+    def render_request(self, completed_request):
+        """Draw the camera image using Qt and OpenGL/GLES."""
+        if self.title_function is not None:
+            self.setWindowTitle(self.title_function(completed_request.get_metadata()))
+        with self.lock:
+            if self.running:
+                eglMakeCurrent(self.egl.display, self.surface, self.surface, self.egl.context)
+                self.repaint(completed_request)
+                eglMakeCurrent(self.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)
+            if self.current_request and self.own_current:
+                self.current_request.release()
+            self.current_request = completed_request
+            self.own_current = (completed_request.config['buffer_count'] > 1)
+            if self.own_current:
+                self.current_request.acquire()
+
     @pyqtSlot()
     def handle_requests(self):
         self.picamera2.notifymeread.read()
-        request = self.picamera2.process_requests()
-        if not request:
-            return
-
-        if self.title_function is not None:
-            self.setWindowTitle(self.title_function(request.get_metadata()))
-        if self.picamera2.display_stream_name is not None:
-            with self.lock:
-                if self.running:
-                    eglMakeCurrent(self.egl.display, self.surface, self.surface, self.egl.context)
-                    self.repaint(request)
-                    eglMakeCurrent(self.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)
-                if self.current_request and self.own_current:
-                    self.current_request.release()
-                self.current_request = request
-            # The pipeline will stall if there's only one buffer and we always hold on to
-            # the last one. When we can, however, holding on to them is still preferred.
-            config = self.picamera2.camera_config
-            if config is not None and config['buffer_count'] > 1:
-                self.own_current = True
-            else:
-                self.own_current = False
-                request.release()
-        else:
-            self.own_current = False
-            request.release()
+        self.picamera2.process_requests(self)
 
     def recalculate_viewport(self):
         window_w = self.width()


### PR DESCRIPTION
These patches tidy up some code and create a "render this request" method for each preview taking code that was previously sandwiched inside handle_request. Now the call to process_requests calls the render method directly so that it can signal back to the user application afterwards, which is how it should be!