### PR TITLE
JpegEncoder: choose the pixel format automatically from the stream

### DIFF
--- a/picamera2/encoders/encoder.py
+++ b/picamera2/encoders/encoder.py
@@ -127,11 +127,8 @@ class Encoder:
         elif value == "XRGB8888":
             self._format = V4L2_PIX_FMT_RGBA32
         else:
-            if type(self) is Encoder:
-                formats.assert_format_valid(value)
-                self._format = value
-            else:
-                raise RuntimeError("Invalid format")
+            formats.assert_format_valid(value)
+            self._format = value
 
     @property
     def output(self):

--- a/picamera2/encoders/jpeg_encoder.py
+++ b/picamera2/encoders/jpeg_encoder.py
@@ -9,7 +9,12 @@ from picamera2.encoders.multi_encoder import MultiEncoder
 class JpegEncoder(MultiEncoder):
     """Uses functionality from MultiEncoder"""
 
-    def __init__(self, num_threads=4, q=None, colour_space='RGBX', colour_subsampling='420'):
+    FORMAT_TABLE = {"XBGR8888": "RGBX",
+                    "XRGB8888": "BGRX",
+                    "BGR888": "RGB",
+                    "RGB888": "BGR"}
+
+    def __init__(self, num_threads=4, q=None, colour_space=None, colour_subsampling='420'):
         """Initialises Jpeg encoder
 
         :param num_threads: Number of threads to use, defaults to 4
@@ -37,6 +42,8 @@ class JpegEncoder(MultiEncoder):
         :return: Jpeg image
         :rtype: bytes
         """
+        if self.colour_space is None:
+            self.colour_space = self.FORMAT_TABLE[request.config[name]["format"]]
         array = request.make_array(name)
         return simplejpeg.encode_jpeg(array, quality=self.q, colorspace=self.colour_space,
                                       colorsubsampling=self.colour_subsampling)


### PR DESCRIPTION
The pixel format (what simplejpeg calls "colorspace") should be chosen automatically from the stream that is being encoded.

Also had to remove a test from the Encoder format method because it was rejecting derived classes and also seems unnecessary as we're in an Encoder method anyway.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>