### PR TITLE
Work around OpenGL error on 64-bit OS Lite builds

### DIFF
--- a/picamera2/previews/qt.py
+++ b/picamera2/previews/qt.py
@@ -1,2 +1,15 @@
-from .q_gl_picamera2 import EglState, QGlPicamera2
+# Installing Qt and OpenGL on the 64-bit Lite OS, and trying to run
+# a remote preview window, causes an error here (the 32-bit Lite OS is OK).
+# It may be something to do with more recent versions of python3-opengl?
+# Anyway, if we carry on regardless at least the non-OpenGL preview works,
+# which is in any case what is required for remote preview windows.
+from logging import getLogger
+
 from .q_picamera2 import QPicamera2
+
+_log = getLogger(__name__)
+
+try:
+    from .q_gl_picamera2 import EglState, QGlPicamera2
+except Exception:
+    _log.warning("OpenGL will not be available")


### PR DESCRIPTION
The 64-bit OS Lite build encounters an OpenGL error when trying to start a remote preview window. This just works around the problem, letting the non-OpenGL preview work as expected.

The 32-bit OS Lite works, so the root cause of the error is not really understood.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>