### PR TITLE
Imx708 test fixes

### DIFF
--- a/examples/switch_mode.py
+++ b/examples/switch_mode.py
@@ -15,7 +15,14 @@ picam2.configure(preview_config)
 picam2.start()
 time.sleep(2)
 
-other_config = picam2.create_preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
+size = picam2.sensor_resolution
+# GPU won't digest images wider than 4096 on a Pi 4.
+if size[0] > 4096:
+    height = size[1] * 4096 // size[0]
+    height -= height % 2
+    size = (4096, height)
+
+other_config = picam2.create_preview_configuration(main={"size": size}, buffer_count=2)
 
 picam2.switch_mode(other_config)
 time.sleep(2)

--- a/examples/switch_mode_2.py
+++ b/examples/switch_mode_2.py
@@ -16,7 +16,14 @@ picam2.start()
 time.sleep(2)
 picam2.stop()
 
-other_config = picam2.create_preview_configuration(main={"size": picam2.sensor_resolution}, buffer_count=3)
+size = picam2.sensor_resolution
+# GPU won't digest images wider than 4096 on a Pi 4.
+if size[0] > 4096:
+    height = size[1] * 4096 // size[0]
+    height -= height % 2
+    size = (4096, height)
+
+other_config = picam2.create_preview_configuration(main={"size": size}, buffer_count=2)
 picam2.configure(other_config)
 
 picam2.start()


### PR DESCRIPTION
A couple of tests were failing with the imx708 because it makes images wider than the GPU can handle.