### PR TITLE
Convert values in the camera_properties to Python-friendly types

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -328,7 +328,9 @@ class Picamera2:
 
     @property
     def camera_controls(self) -> dict:
-        return {k: (v[1].min, v[1].max, v[1].default) for k, v in self.camera_ctrl_info.items()}
+        return {k: (convert_from_libcamera_type(v[1].min),
+                    convert_from_libcamera_type(v[1].max),
+                    convert_from_libcamera_type(v[1].default)) for k, v in self.camera_ctrl_info.items()}
 
     @property
     def title_fields(self):


### PR DESCRIPTION
For example, libcamera.Rectangle objects are converted to tuples of 4 numbers, as we do for camera_controls. This just makes things more consistent.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>