### PR TITLE
Fix race condition in setting controls

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -967,7 +967,7 @@ class Picamera2:
         else:
             self.video_configuration.update(camera_config)
         # Set the controls directly so as to overwrite whatever is there.
-        self.controls.set_controls(self.camera_config['controls'])
+        self.controls = Controls(self, controls=self.camera_config['controls'])
         self.configure_count += 1
 
     def configure(self, camera_config="preview") -> None:


### PR DESCRIPTION
This change actually makes the code do what was intended all along (according to the comment there). Any controls that were still "pending" when you stopped the camera will now get dropped.

This matters when you set a control and then stop the camera either immediately or after a delay. There are 3 things that can happen:

1. If you wait long enough, libcamera will receive the control and apply it. So the control update happens.

2. If you wait just a "little" while, the control will go to libcamera, but libcamera won't have long enough to apply it, so the change is lost. Picamera2 cannot influence this.

3. If you don't wait at all, the control is still "pending". In the old scheme, the change would now take effect when you restart the camera, but this commit alters the behaviour so that it is dropped.

In some respects the old behaviour in case 3 was nice, but given case 2, it leads to a highly unpredictable outcome - does the change happen or not? So making case 3 drop the update make the behaviour easier to control. An application can always set the control again before the camera is restarted to be sure it will be applied.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>