### PR TITLE
Add more type hints

### DIFF
--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -1,8 +1,10 @@
+from typing import Any, Union
+
 from .controls import Controls
 
 
 class Configuration:
-    def __init__(self, d={}):
+    def __init__(self, d: Union[dict[str, Any], "Configuration"] = {}) -> None:
         """A small wrapper class that can be used to turn our configuration dicts into real objects.
 
         The constructor can make an empty object, or initialise from a dict. There is also the
@@ -34,7 +36,7 @@ class Configuration:
         for k, v in d.items():
             self.__setattr__(k, v)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         if name in self._FORWARD_FIELDS:
             target = self._FORWARD_FIELDS[name]
             self.__getattribute__(target).__setattr__(name, value)
@@ -45,7 +47,7 @@ class Configuration:
         else:
             raise RuntimeError(f"Invalid field '{name}'")
 
-    def __getattribute__(self, name):
+    def __getattribute__(self, name: str) -> Any:
         if name in super().__getattribute__("_FORWARD_FIELDS"):
             return super().__getattribute__(self._FORWARD_FIELDS[name]).__getattribute__(name)
         else:
@@ -54,11 +56,11 @@ class Configuration:
     def __repr__(self):
         return type(self).__name__ + "(" + repr(self.make_dict()) + ")"
 
-    def update(self, update_dict):
+    def update(self, update_dict: dict[str, Any]) -> None:
         for k, v in update_dict.items():
             self.__setattr__(k, v)
 
-    def make_dict(self):
+    def make_dict(self) -> dict[str, Any]:
         d = {}
         for f in self._ALLOWED_FIELDS:
             if hasattr(self, f):
@@ -68,7 +70,7 @@ class Configuration:
                 d[f] = value
         return d
 
-    def align(self, optimal=True):
+    def align(self, optimal: bool = True) -> None:
         if optimal:
             # Adjust the image size so that all planes are a mutliple of 32 bytes wide.
             # This matches the hardware behaviour and means we can be more efficient.
@@ -94,24 +96,24 @@ class CameraConfiguration(Configuration):
     _FIELD_CLASS_MAP = {"main": StreamConfiguration, "lores": StreamConfiguration, "raw": StreamConfiguration}
     _FORWARD_FIELDS = {"size": "main", "format": "main"}
 
-    def __init__(self, d={}, picam2=None):
+    def __init__(self, d: dict[str, Any] = {}, picam2=None) -> None:
         # Can't convert "controls" dicts to Controls objects automatically, so do it here:
         d = {k: v if k != "controls" else Controls(picam2, v) for k, v in d.items()}
         super().__init__(d)
 
-    def enable_lores(self, onoff=True):
+    def enable_lores(self, onoff: bool = True) -> None:
         if onoff:
             self.lores = StreamConfiguration({"size": self.main.size, "format": "YUV420"})
         else:
             self.lores = None
 
-    def enable_raw(self, onoff=True):
+    def enable_raw(self, onoff: bool = True) -> None:
         if onoff:
             self.raw = StreamConfiguration({"size": self.main.size, "format": None})
         else:
             self.raw = None
 
-    def align(self, optimal=True):
+    def align(self, optimal: bool = True) -> None:
         self.main.align(optimal)
         if self.lores is not None:
             self.lores.align(optimal)

--- a/picamera2/converters.py
+++ b/picamera2/converters.py
@@ -5,7 +5,11 @@ YUV2RGB_SMPTE170M = np.array([[1.164, 1.164, 1.164], [0.0, -0.392, 2.017], [1.59
 YUV2RGB_REC709    = np.array([[1.164, 1.164, 1.164], [0.0, -0.213, 2.112], [1.793, -0.533, 0.0]]) # noqa
 
 
-def YUV420_to_RGB(YUV_in, size, matrix=YUV2RGB_JPEG, rb_swap=True, final_width=0):
+def YUV420_to_RGB(YUV_in: np.ndarray,
+                  size: tuple[int, int],
+                  matrix: np.ndarray = YUV2RGB_JPEG,
+                  rb_swap: bool = True,
+                  final_width: int = 0) -> np.ndarray:
     """Convert a YUV420 image to an interleaved RGB image of half resolution.
 
     The size parameter should include padding if there is any, which can be trimmed off

--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -1,6 +1,7 @@
 """H264 encoder functionality"""
 
 from math import sqrt
+from typing import Optional
 
 from v4l2 import (V4L2_CID_MPEG_VIDEO_H264_I_PERIOD,
                   V4L2_CID_MPEG_VIDEO_REPEAT_SEQ_HEADER, V4L2_PIX_FMT_H264)
@@ -12,7 +13,10 @@ from picamera2.encoders.v4l2_encoder import V4L2Encoder
 class H264Encoder(V4L2Encoder):
     """Uses functionality from V4L2Encoder"""
 
-    def __init__(self, bitrate=None, repeat=True, iperiod=None):
+    def __init__(self,
+                 bitrate: Optional[int] = None,
+                 repeat: bool = True,
+                 iperiod: Optional[int] = None) -> None:
         """H264 Encoder
 
         :param bitrate: Bitrate, default None
@@ -28,7 +32,7 @@ class H264Encoder(V4L2Encoder):
         if repeat:
             self._controls += [(V4L2_CID_MPEG_VIDEO_REPEAT_SEQ_HEADER, 1)]
 
-    def _setup(self, quality):
+    def _setup(self, quality: Quality) -> None:
         if self._requested_bitrate is None:
             # These are suggested bitrates for 1080p30 in Mbps
             BITRATE_TABLE = {Quality.VERY_LOW: 2,

--- a/picamera2/encoders/jpeg_encoder.py
+++ b/picamera2/encoders/jpeg_encoder.py
@@ -1,4 +1,5 @@
 """JPEG encoder functionality"""
+from typing import Optional
 
 import simplejpeg
 
@@ -14,7 +15,11 @@ class JpegEncoder(MultiEncoder):
                     "BGR888": "RGB",
                     "RGB888": "BGR"}
 
-    def __init__(self, num_threads=4, q=None, colour_space=None, colour_subsampling='420'):
+    def __init__(self,
+                 num_threads: int = 4,
+                 q: Optional[Quality] = None,
+                 colour_space: Optional[str] = None,
+                 colour_subsampling: str = '420') -> None:
         """Initialises Jpeg encoder
 
         :param num_threads: Number of threads to use, defaults to 4
@@ -32,7 +37,7 @@ class JpegEncoder(MultiEncoder):
         self.colour_space = colour_space
         self.colour_subsampling = colour_subsampling
 
-    def encode_func(self, request, name):
+    def encode_func(self, request, name: str) -> bytes:
         """Performs encoding
 
         :param request: Request
@@ -48,7 +53,7 @@ class JpegEncoder(MultiEncoder):
         return simplejpeg.encode_jpeg(array, quality=self.q, colorspace=self.colour_space,
                                       colorsubsampling=self.colour_subsampling)
 
-    def _setup(self, quality):
+    def _setup(self, quality: Quality) -> None:
         if self.requested_q is None:
             # Image size and framerate isn't an issue here, you just get what you get.
             Q_TABLE = {Quality.VERY_LOW: 20,

--- a/picamera2/encoders/mjpeg_encoder.py
+++ b/picamera2/encoders/mjpeg_encoder.py
@@ -1,6 +1,7 @@
 """MJPEG encoder functionality utilising V4L2"""
 
 from math import sqrt
+from typing import Optional
 
 from v4l2 import V4L2_PIX_FMT_MJPEG
 
@@ -11,7 +12,7 @@ from picamera2.encoders.v4l2_encoder import V4L2Encoder
 class MJPEGEncoder(V4L2Encoder):
     """MJPEG encoder utilsing V4L2 functionality"""
 
-    def __init__(self, bitrate=None):
+    def __init__(self, bitrate: Optional[int] = None) -> None:
         """Creates MJPEG encoder
 
         :param bitrate: Bitrate, default None
@@ -19,7 +20,7 @@ class MJPEGEncoder(V4L2Encoder):
         """
         super().__init__(bitrate, V4L2_PIX_FMT_MJPEG)
 
-    def _setup(self, quality):
+    def _setup(self, quality: Quality) -> None:
         if self._requested_bitrate is None:
             # These are suggested bitrates for 1080p30 in Mbps
             BITRATE_TABLE = {Quality.VERY_LOW: 6,

--- a/picamera2/encoders/multi_encoder.py
+++ b/picamera2/encoders/multi_encoder.py
@@ -18,7 +18,7 @@ class MultiEncoder(Encoder):
     best performance.
     """
 
-    def __init__(self, num_threads=4):
+    def __init__(self, num_threads: int = 4) -> None:
         """Initialise mult-threaded encoder
 
         :param num_threads: Number of threads to use, defaults to 4
@@ -28,15 +28,15 @@ class MultiEncoder(Encoder):
         self.threads = ThreadPoolExecutor(num_threads)
         self.tasks = queue.Queue()
 
-    def _start(self):
+    def _start(self) -> None:
         self.thread = threading.Thread(target=self.output_thread, daemon=True)
         self.thread.start()
 
-    def _stop(self):
+    def _stop(self) -> None:
         self.tasks.put(None)
         self.thread.join()
 
-    def output_thread(self):
+    def output_thread(self) -> None:
         """Outputs frame"""
         while True:
             task = self.tasks.get()
@@ -47,7 +47,7 @@ class MultiEncoder(Encoder):
             if self.output:
                 self.outputframe(buffer, timestamp=timestamp_us)
 
-    def do_encode(self, request, stream):
+    def do_encode(self, request, stream) -> tuple[bytes, int]:
         """Encodes frame in a thread
 
         :param request: Request
@@ -59,7 +59,7 @@ class MultiEncoder(Encoder):
         request.release()
         return (buffer, timestamp_us)
 
-    def _encode(self, stream, request):
+    def _encode(self, stream, request) -> None:
         """Encode frame using a thread
 
         :param stream: Stream
@@ -69,6 +69,6 @@ class MultiEncoder(Encoder):
             request.acquire()
             self.tasks.put(self.threads.submit(self.do_encode, request, stream))
 
-    def encode_func(self, request, name):
+    def encode_func(self, request, name) -> bytes:
         """Empty function, which will be overriden"""
         return b""

--- a/picamera2/encoders/v4l2_encoder.py
+++ b/picamera2/encoders/v4l2_encoder.py
@@ -6,6 +6,7 @@ import mmap
 import queue
 import select
 import threading
+from typing import Optional
 
 from v4l2 import *
 
@@ -15,7 +16,7 @@ from picamera2.encoders.encoder import Encoder
 class V4L2Encoder(Encoder):
     """V4L2 Encoding"""
 
-    def __init__(self, bitrate, pixformat):
+    def __init__(self, bitrate: Optional[int], pixformat: int) -> None:
         """Initialise V4L2 encoder
 
         :param bitrate: Bitrate
@@ -31,7 +32,7 @@ class V4L2Encoder(Encoder):
         self._controls = []
         self.vd = None
 
-    def _start(self):
+    def _start(self) -> None:
         self.vd = open('/dev/video11', 'rb+', buffering=0)
 
         self.buf_available = queue.Queue()
@@ -125,7 +126,7 @@ class V4L2Encoder(Encoder):
         typev = v4l2_buf_type(V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE)
         fcntl.ioctl(self.vd, VIDIOC_STREAMON, typev)
 
-    def _stop(self):
+    def _stop(self) -> None:
         self.thread.join()
         typev = v4l2_buf_type(V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE)
         fcntl.ioctl(self.vd, VIDIOC_STREAMOFF, typev)
@@ -149,7 +150,7 @@ class V4L2Encoder(Encoder):
         fcntl.ioctl(self.vd, VIDIOC_REQBUFS, reqbufs)
         self.vd.close()
 
-    def thread_poll(self, buf_available):
+    def thread_poll(self, buf_available: queue.Queue) -> None:
         """Outputs encoded frames"""
         pollit = select.poll()
         pollit.register(self.vd, select.POLLIN)
@@ -204,7 +205,7 @@ class V4L2Encoder(Encoder):
                         queue_item = self.buf_frame.get()
                         queue_item.release()
 
-    def _encode(self, stream, request):
+    def _encode(self, stream, request) -> None:
         """Encodes a frame
 
         :param stream: Stream

--- a/picamera2/job.py
+++ b/picamera2/job.py
@@ -1,4 +1,5 @@
 from concurrent.futures import Future
+from typing import Callable, Optional
 
 
 class Job:
@@ -20,7 +21,7 @@ class Job:
     Picamera2.switch_mode_and_capture_array.
     """
 
-    def __init__(self, functions, signal_function=None):
+    def __init__(self, functions: list[Callable], signal_function: Optional[Callable] = None) -> None:
         self._functions = functions
         self._future = Future()
         self._future.set_running_or_notify_cancel()
@@ -31,7 +32,7 @@ class Job:
         # of frames it took for things to finish, maybe intermediate results...
         self.calls = 0
 
-    def execute(self):
+    def execute(self) -> bool:
         """Try to execute this Job.
 
         It will return True if it finishes, or False if it needs to be tried again.
@@ -59,7 +60,7 @@ class Job:
 
         return not self._functions
 
-    def signal(self):
+    def signal(self) -> None:
         """Signal that the job is finished."""
         assert not self._functions, "Job not finished!"
 

--- a/picamera2/metadata.py
+++ b/picamera2/metadata.py
@@ -1,10 +1,10 @@
 
 class Metadata():
-    def __init__(self, metadata={}):
+    def __init__(self, metadata: dict = {}) -> None:
         self.__dict__ = metadata.copy()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<Metadata: {self.__dict__}>"
 
-    def make_dict(self):
+    def make_dict(self) -> dict:
         return self.__dict__.copy()

--- a/picamera2/outputs/circularoutput.py
+++ b/picamera2/outputs/circularoutput.py
@@ -1,7 +1,9 @@
 """Circular buffer"""
 
 import collections
+import io
 from multiprocessing import Lock
+from typing import Optional, Union
 
 from .fileoutput import FileOutput
 
@@ -9,7 +11,11 @@ from .fileoutput import FileOutput
 class CircularOutput(FileOutput):
     """Circular buffer implementation for file output"""
 
-    def __init__(self, file=None, pts=None, buffersize=30 * 5, outputtofile=True):
+    def __init__(self,
+                 file: Union[None, str, io.BufferedIOBase] = None,
+                 pts: Union[None, str, io.BufferedWriter] = None,
+                 buffersize: int = 30 * 5,
+                 outputtofile: bool = True) -> None:
         """Creates circular buffer for 5s worth of 30fps frames
 
         :param file: File to write frames to, defaults to None
@@ -27,12 +33,12 @@ class CircularOutput(FileOutput):
         self.outputtofile = outputtofile
 
     @property
-    def buffersize(self):
+    def buffersize(self) -> int:
         """Returns size of buffer"""
         return self._buffersize
 
     @buffersize.setter
-    def buffersize(self, value):
+    def buffersize(self, value: int) -> None:
         """Create buffer for specified number of frames"""
         if not isinstance(value, int):
             raise RuntimeError("Buffer size must be integer")
@@ -40,7 +46,7 @@ class CircularOutput(FileOutput):
             self._buffersize = value
             self._circular = collections.deque(maxlen=value)
 
-    def outputframe(self, frame, keyframe=True, timestamp=None):
+    def outputframe(self, frame: bytes, keyframe: bool = True, timestamp: Optional[int] = None) -> None:
         """Write frame to circular buffer
 
         :param frame: Frame
@@ -71,7 +77,7 @@ class CircularOutput(FileOutput):
                     frame, keyframe = self._circular.popleft()
                 self._write(frame, timestamp)
 
-    def stop(self):
+    def stop(self) -> None:
         """Close file handle and prevent recording"""
         self.recording = False
         key = False

--- a/picamera2/outputs/fileoutput.py
+++ b/picamera2/outputs/fileoutput.py
@@ -3,6 +3,7 @@
 import io
 import socket
 import types
+from typing import Any, Callable, Optional, Union
 
 from .output import Output
 
@@ -10,7 +11,10 @@ from .output import Output
 class FileOutput(Output):
     """File handling functionality for encoders"""
 
-    def __init__(self, file=None, pts=None, split=None):
+    def __init__(self,
+                 file: Union[None, str, io.BufferedIOBase] = None,
+                 pts: Union[None, str, io.BufferedWriter] = None,
+                 split: Optional[int] = None) -> None:
         """Initialise file output
 
         :param file: File to write frames to, defaults to None
@@ -25,16 +29,16 @@ class FileOutput(Output):
         self.fileoutput = file
         self._firstframe = True
         self._before = None
-        self._connectiondead = None
+        self._connectiondead: Optional[Callable[[str], Any]] = None
         self._splitsize = split
 
     @property
-    def fileoutput(self):
+    def fileoutput(self) -> Optional[io.BufferedIOBase]:
         """Return file handle"""
         return self._fileoutput
 
     @fileoutput.setter
-    def fileoutput(self, file):
+    def fileoutput(self, file: Union[None, str, io.BufferedIOBase]) -> None:
         """Change file to output frames to"""
         self._split = False
         self._firstframe = True
@@ -52,12 +56,12 @@ class FileOutput(Output):
                 self._split = True
 
     @property
-    def connectiondead(self):
+    def connectiondead(self) -> Optional[Callable[[str], Any]]:
         """Return callback"""
         return self._connectiondead
 
     @connectiondead.setter
-    def connectiondead(self, _callback):
+    def connectiondead(self, _callback: Optional[Callable[[str], Any]]):
         """Callback for passing exceptions
 
         :param _callback: Callback that is called when exception caught
@@ -69,7 +73,7 @@ class FileOutput(Output):
         else:
             raise RuntimeError("Must pass callback function or None")
 
-    def outputframe(self, frame, keyframe=True, timestamp=None):
+    def outputframe(self, frame: bytes, keyframe: bool = True, timestamp: Optional[int] = None) -> None:
         """Outputs frame from encoder
 
         :param frame: Frame
@@ -87,12 +91,12 @@ class FileOutput(Output):
                     self._firstframe = False
             self._write(frame, timestamp)
 
-    def stop(self):
+    def stop(self) -> None:
         """Close file handle and prevent recording"""
         super().stop()
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         """Closes all files"""
         try:
             self._fileoutput.close()
@@ -101,7 +105,7 @@ class FileOutput(Output):
             if self._connectiondead is not None:
                 self._connectiondead(e)
 
-    def _write(self, frame, timestamp=None):
+    def _write(self, frame: bytes, timestamp: Optional[int] = None) -> None:
         try:
             if self._split:
                 maxsize = 65507 if self._splitsize is None else self._splitsize

--- a/picamera2/outputs/output.py
+++ b/picamera2/outputs/output.py
@@ -1,10 +1,13 @@
 """Output frames from encoder"""
 
+import io
+from typing import Optional, Union
+
 
 class Output:
     """Handles output functionality of encoders"""
 
-    def __init__(self, pts=None):
+    def __init__(self, pts: Union[None, str, io.BufferedWriter] = None) -> None:
         """Start output, with recording set to False
 
         :param pts: File to write timestamps to, defaults to None
@@ -13,15 +16,15 @@ class Output:
         self.recording = False
         self.ptsoutput = pts
 
-    def start(self):
+    def start(self) -> None:
         """Start recording"""
         self.recording = True
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop recording"""
         self.recording = False
 
-    def outputframe(self, frame, keyframe=True, timestamp=None):
+    def outputframe(self, frame: bytes, keyframe: bool = True, timestamp: Optional[int] = None) -> None:
         """Outputs frame from encoder
 
         :param frame: Frame
@@ -32,7 +35,7 @@ class Output:
         :type timestamp: int
         """
 
-    def outputtimestamp(self, timestamp):
+    def outputtimestamp(self, timestamp: Optional[int]) -> None:
         """Output timestamp to file
 
         :param timestamp: Timestamp to write to file
@@ -42,12 +45,12 @@ class Output:
             print(f"{timestamp // 1000}.{timestamp % 1000:03}", file=self.ptsoutput, flush=True)
 
     @property
-    def ptsoutput(self):
+    def ptsoutput(self) -> Optional[io.BufferedWriter]:
         """Return file handle"""
         return self._ptsoutput
 
     @ptsoutput.setter
-    def ptsoutput(self, file):
+    def ptsoutput(self, file: Union[None, str, io.BufferedWriter]):
         """Change file to output pts file to"""
         if file is None:
             self._ptsoutput = None

--- a/picamera2/sensor_format.py
+++ b/picamera2/sensor_format.py
@@ -5,7 +5,7 @@ from libcamera import Transform
 
 
 class SensorFormat():
-    def __init__(self, fmt_string):
+    def __init__(self, fmt_string: str) -> None:
         if "_" in fmt_string:
             pixels, self.packing = fmt_string.split("_")
         else:
@@ -15,21 +15,21 @@ class SensorFormat():
         self.bayer_order = re.search("[RGB]+", pixels).group()
 
     @property
-    def format(self):
+    def format(self) -> str:
         return f"{self.unpacked}{f'_{self.packing}' if self.packing else ''}"
 
     @property
-    def unpacked(self):
+    def unpacked(self) -> str:
         return f"{'' if self.mono else 'S'}{self.bayer_order}{self.bit_depth}"
 
     @property
-    def mono(self):
+    def mono(self) -> bool:
         return self.bayer_order == "R"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.format
 
-    def transform(self, transform: Transform):
+    def transform(self, transform: Transform) -> None:
         if self.mono:
             return
         bayer_array = np.reshape(list(self.bayer_order), (2, 2))

--- a/picamera2/utils.py
+++ b/picamera2/utils.py
@@ -1,7 +1,13 @@
+from typing import Union
+
 from libcamera import Rectangle, Size
 
 
-def convert_from_libcamera_type(value):
+def convert_from_libcamera_type(value: Union[Rectangle, Size, list[Rectangle]],
+                                ) -> Union[tuple[int, int, int, int],
+                                           tuple[int, int],
+                                           list[tuple[int, int, int, int]]
+                                           ]:
     if isinstance(value, Rectangle):
         value = (value.x, value.y, value.width, value.height)
     elif isinstance(value, Size):


### PR DESCRIPTION
Greetings!

As type hints are pretty nice to have IMO, I added some type hints to various functions and methods.
This should make it easier for the user to use the `picamera` functionality as well as for the maintainers to refactor existing code.

As the project is on Python 3.9+, the built-in types like `dict`, `list` and `tuple` can be used directly instead of using the deprecated `typing` types like [typing.Dict](https://docs.python.org/3/library/typing.html#typing.Dict), [typing.List](https://docs.python.org/3/library/typing.html#typing.List) and [typing.Tuple](https://docs.python.org/3/library/typing.html#typing.Tuple).

Signed-off-by: Creno Eno <creno.eno@protonmail.com>