### PR TITLE
Fix new flake8 B028 warning

### DIFF
--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -43,7 +43,7 @@ class Configuration:
                 value = self._FIELD_CLASS_MAP[name](value)
             super().__setattr__(name, value)
         else:
-            raise RuntimeError(f"Invalid field '{name}'")
+            raise RuntimeError(f"Invalid field {name!r}")
 
     def __getattribute__(self, name):
         if name in super().__getattribute__("_FORWARD_FIELDS"):

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -596,7 +596,7 @@ class Picamera2:
             elif key in ignore_list:
                 pass  # allows us to pass items from the sensor_modes as a raw stream
             else:
-                raise ValueError(f"Bad key '{key}': valid stream configuration keys are {valid}")
+                raise ValueError(f"Bad key {key!r}: valid stream configuration keys are {valid}")
         return stream_config
 
     @staticmethod
@@ -736,7 +736,7 @@ class Picamera2:
         required_keys = ["colour_space", "transform", "main", "lores", "raw"]
         for name in required_keys:
             if name not in camera_config:
-                raise RuntimeError(f"'{name}' key expected in camera configuration")
+                raise RuntimeError(f"{name!r} key expected in camera configuration")
 
         # Check the entire camera configuration for errors.
         if not isinstance(camera_config["colour_space"], libcamera._libcamera.ColorSpace):

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -141,7 +141,7 @@ class CompletedRequest:
     def make_buffer(self, name):
         """Make a 1d numpy array from the named stream's buffer."""
         if self.stream_map.get(name, None) is None:
-            raise RuntimeError(f'Stream "{name}" is not defined')
+            raise RuntimeError(f'Stream {name!r} is not defined')
         with _MappedBuffer(self, name) as b:
             return np.array(b, dtype=np.uint8)
 


### PR DESCRIPTION
This appears to be a new warning from the latest flake8 release. It prefers the string syntax `f"{variable!r}"` over `f"'{variable}'"`.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>