### PR TITLE
Allow H264 headers to specify a framerate

### DIFF
--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -12,7 +12,7 @@ from picamera2.encoders.v4l2_encoder import V4L2Encoder
 class H264Encoder(V4L2Encoder):
     """Uses functionality from V4L2Encoder"""
 
-    def __init__(self, bitrate=None, repeat=True, iperiod=None):
+    def __init__(self, bitrate=None, repeat=True, iperiod=None, framerate=None, enable_sps_framerate=False):
         """H264 Encoder
 
         :param bitrate: Bitrate, default None
@@ -21,12 +21,18 @@ class H264Encoder(V4L2Encoder):
         :type repeat: bool, optional
         :param iperiod: Iperiod, defaults to None
         :type iperiod: int, optional
+        :param framerate: record a framerate in the stream (whether true or not)
+        :type framerate: float, optional
         """
         super().__init__(bitrate, V4L2_PIX_FMT_H264)
         if iperiod is not None:
             self._controls += [(V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, iperiod)]
         if repeat:
             self._controls += [(V4L2_CID_MPEG_VIDEO_REPEAT_SEQ_HEADER, 1)]
+        # The framerate can be reported in the sequence headers if enable_sps_framerate is set,
+        # but there's no guarantee that frames will be delivered to the codec at that rate!
+        self._framerate = framerate
+        self._enable_framerate = enable_sps_framerate
 
     def _setup(self, quality):
         if self._requested_bitrate is None:

--- a/picamera2/encoders/v4l2_encoder.py
+++ b/picamera2/encoders/v4l2_encoder.py
@@ -30,6 +30,7 @@ class V4L2Encoder(Encoder):
         self._pixformat = pixformat
         self._controls = []
         self.vd = None
+        self._framerate = None
 
     def _start(self):
         self.vd = open('/dev/video11', 'rb+', buffering=0)
@@ -71,6 +72,16 @@ class V4L2Encoder(Encoder):
         fmt.fmt.pix_mp.plane_fmt[0].bytesperline = 0
         fmt.fmt.pix_mp.plane_fmt[0].sizeimage = 512 << 10
         fcntl.ioctl(self.vd, VIDIOC_S_FMT, fmt)
+
+        if self._framerate is not None and self._enable_framerate:
+            # Some codecs, such as H264, support this parameter. Our other codecs do not,
+            # and do not allow you to set the _framerate property.
+            sparm = v4l2_streamparm()
+            sparm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE
+            sparm.parm.output.capabilities = V4L2_CAP_TIMEPERFRAME
+            sparm.parm.output.timeperframe.numerator = 1000
+            sparm.parm.output.timeperframe.denominator = round(self._framerate * 1000)
+            fcntl.ioctl(self.vd, VIDIOC_S_PARM, sparm)
 
         if len(self._controls) > 0:
             controlarr = (v4l2_ext_control * len(self._controls))()


### PR DESCRIPTION
This is merely a number in the H264 SPS headers - it may or may not actually be true. The codec has no idea when frames will actually be delivered to it.

It's optional whether to supply this number, and in most cases, unless you specifically need a value in the headers, we would recommend omitting it and driving the camera however you like.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>