### PR TITLE
Fix `switch_mode_and_capture_image` method

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1433,7 +1433,7 @@ class Picamera2:
 
         functions = [partial(self.switch_mode_, camera_config),
                      partial(capture_image_and_switch_back_, self, preview_config, name)]
-        self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function)
 
     def start_encoder(self, encoder=None, output=None, pts=None, quality=Quality.MEDIUM) -> None:
         """Start encoder


### PR DESCRIPTION
Fixes #557 
Its looks like `return` was unintentionally omitted in [PR 436 ](https://github.com/raspberrypi/picamera2/commit/cff52ea865c954d6faa4e00f0003e16d7fc7d710#diff-26e92d0368f682e2f447e8e5c597e95d27f67eff88e4345d3d4fff4226eb8fcbR1449)