### PR TITLE
Update to work with the new libcamera colour space scheme

### DIFF
--- a/picamera2/utils.py
+++ b/picamera2/utils.py
@@ -1,4 +1,6 @@
-from libcamera import Rectangle, Size
+from libcamera import ColorSpace, Rectangle, Size
+
+import picamera2.formats as formats
 
 
 def convert_from_libcamera_type(value):
@@ -9,3 +11,27 @@ def convert_from_libcamera_type(value):
     elif isinstance(value, list) and all(isinstance(item, Rectangle) for item in value):
         value = [(v.x, v.y, v.width, v.height) for v in value]
     return value
+
+
+def colour_space_to_libcamera(colour_space, format):
+    # libcamera may complain if we supply an RGB format stream with a YCbCr matrix or range.
+    if formats.is_RGB(format):
+        colour_space = ColorSpace(colour_space)  # it could be shared with other streams, so copy it
+        colour_space.ycbcrEncoding = ColorSpace.YcbcrEncoding.Null
+        colour_space.range = ColorSpace.Range.Full
+    return colour_space
+
+
+COLOUR_SPACE_TABLE = {ColorSpace.Sycc(), ColorSpace.Smpte170m(), ColorSpace.Rec709()}
+
+
+def colour_space_from_libcamera(colour_space):
+    # Colour spaces may come back from libcamera without a YCbCr matrix or range, meaning
+    # they don't look like the 3 standard colour spaces (in the table) that we expect people
+    # to use. Let's fix that.
+    if colour_space is None:  # USB webcams might have a "None" colour space
+        return None
+    for cs in COLOUR_SPACE_TABLE:
+        if colour_space.primaries == cs.primaries and colour_space.transferFunction == cs.transferFunction:
+            return cs
+    return colour_space

--- a/tests/colour_spaces.py
+++ b/tests/colour_spaces.py
@@ -1,0 +1,70 @@
+from libcamera import ColorSpace
+
+import picamera2.formats as formats
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+
+
+def configure_and_check(config):
+    check_colour_space = ColorSpace(config["colour_space"])
+    picam2.configure(config)
+    config = picam2.camera_config
+
+    if config["colour_space"] == check_colour_space:
+        print("Headline colour space matches", check_colour_space)
+    else:
+        print("ERROR: headline colour space changed from", check_colour_space, "to", config["colour_space"])
+        quit()
+
+    check_main_colour_space = ColorSpace(check_colour_space)
+    if formats.is_RGB(config["main"]["format"]):
+        check_main_colour_space.ycbcrEncoding = ColorSpace.YcbcrEncoding.Null
+        check_main_colour_space.range = ColorSpace.Range.Full
+
+    libcamera_config = picam2.libcamera_config
+
+    if libcamera_config.at(picam2.main_index).color_space == check_main_colour_space:
+        print("Main stream colour spaces match", check_main_colour_space)
+    else:
+        print("ERROR: main stream colour space is", libcamera_config.at(picam2.main_index).color_space,
+              "expected", check_main_colour_space)
+        quit()
+
+    if picam2.lores_index >= 0:
+        if libcamera_config.at(picam2.lores_index).color_space == check_colour_space:
+            print("Lores stream colour spaces match", check_colour_space)
+        else:
+            print("ERROR: lores stream colour space is", libcamera_config.at(picam2.lores_index).color_space,
+                  "expected", check_colour_space)
+            quit()
+
+    if picam2.raw_index >= 0:
+        if libcamera_config.at(picam2.raw_index).color_space == ColorSpace.Raw():
+            print("Raw stream colour spaces match", ColorSpace.Raw())
+        else:
+            print("ERROR: raw stream colour space is", libcamera_config.at(picam2.raw_index).color_space,
+                  "expected", ColorSpace.Raw())
+            quit()
+
+
+for colour_space in (ColorSpace.Sycc(), ColorSpace.Smpte170m(), ColorSpace.Rec709()):
+
+    for format in ("RGB888", "YUV420"):
+        print("Checking with colour space", colour_space, "and format", format)
+
+        print("Main only")
+        config = picam2.create_preview_configuration({"format": format}, colour_space=colour_space)
+        configure_and_check(config)
+
+        print("Main and lores", flush=True)
+        config = picam2.create_preview_configuration({"format": format}, lores={}, colour_space=colour_space)
+        configure_and_check(config)
+
+        print("Main and raw", flush=True)
+        config = picam2.create_preview_configuration({"format": format}, raw={}, colour_space=colour_space)
+        configure_and_check(config)
+
+        print("Main, lores and raw", flush=True)
+        config = picam2.create_preview_configuration({"format": format}, lores={}, raw={}, colour_space=colour_space)
+        configure_and_check(config)

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -47,6 +47,7 @@ tests/async_test.py
 tests/check_timestamps.py
 tests/close_test.py
 tests/close_test_multiple.py
+tests/colour_spaces.py
 tests/configurations.py
 tests/context_test.py
 tests/display_transform_null.py


### PR DESCRIPTION
The raspberrypi/libcamera next branch has been updated to adopt the latest colour space implementation in libcamera. The update here is required to make Picamera2 work with it again. Note that the Picamera2 next branch probably won't work with the libcamera main branch any more, until we do another release.

There's also a test here which tests every format and colour space combination to exhaustion, so hopefully we'll notice quickly if colour spaces get broken again!