### PR TITLE
Circular buffer flushing

### DIFF
--- a/picamera2/outputs/circularoutput.py
+++ b/picamera2/outputs/circularoutput.py
@@ -73,18 +73,17 @@ class CircularOutput(FileOutput):
 
     def stop(self):
         """Close file handle and prevent recording"""
-        self.recording = False
-        key = False
+        if not self.recording or self._fileoutput is None:
+            return
         with self._lock:
             while self._circular:
                 frame, keyframe = self._circular.popleft()
-                if not self.outputtofile:
-                    if not key:
-                        if keyframe:
-                            self._write(frame)
-                            key = True
-                    else:
+                if self._firstframe:
+                    if keyframe:
                         self._write(frame)
+                        self._firstframe = False
                 else:
                     self._write(frame)
+        self.recording = False
+        self._firstframe = False
         self.close()

--- a/picamera2/outputs/fileoutput.py
+++ b/picamera2/outputs/fileoutput.py
@@ -38,11 +38,13 @@ class FileOutput(Output):
         """Change file to output frames to"""
         self._split = False
         self._firstframe = True
+        self._needs_close = False
         if file is None:
             self._fileoutput = None
         else:
             if isinstance(file, str):
                 self._fileoutput = open(file, "wb")
+                self._needs_close = True
             elif isinstance(file, io.BufferedIOBase):
                 self._fileoutput = file
             else:
@@ -95,7 +97,8 @@ class FileOutput(Output):
     def close(self):
         """Closes all files"""
         try:
-            self._fileoutput.close()
+            if self._needs_close:
+                self._fileoutput.close()
         except (ConnectionResetError, ConnectionRefusedError, BrokenPipeError) as e:
             self.dead = True
             if self._connectiondead is not None:


### PR DESCRIPTION
This PR tries to implement the "copying and clearing" of the circular buffer using the existing functions (rather than a new one), on the grounds that it seems like they mostly should be able to do this already.

I found a couple of issues.

Firstly, the FileOutput class has a tendency to close files even when it didn't open them - which makes it pointless to supply a BytesIO for the output. So I've changed it to close only the files that it opened.

Secondly, the CircularOutput class wasn't checking if it was still recording before writing stuff out when you stop it, meaning that you get extra unwanted stuff if you call stop() twice (which happens easily).

@chrisruk Please let me know what you think. If we think this is the way to go then I'll add an example too. For completeness, the script that these changes enable is as follows:
```
import io
import time

from picamera2 import Picamera2
from picamera2.encoders import H264Encoder
from picamera2.outputs import CircularOutput

FRAMERATE = 30
DURATION = 2

encoder = H264Encoder()
output = CircularOutput(buffersize=FRAMERATE * DURATION)

picam2 = Picamera2()
config = picam2.create_video_configuration(controls={'FrameRate': FRAMERATE})
picam2.configure(config)

picam2.start_recording(encoder, output)
time.sleep(5)

# This writes out the circular buffer and flushes it
data = io.BytesIO()
output.fileoutput = data
output.start()
output.stop()
output.fileoutput = None

picam2.stop_recording()
```
Slightly annoyingly, the `output.start()` line isn't needed because `start_recording` already starts the output. But it _would_ be needed if you wanted to repeat the process again later (because of course `output.stop()` has now stopped it!).