### PR TITLE
Fix bug where unwanted 'bpp' field in the camera config causes crash

### DIFF
--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -283,7 +283,7 @@ class Helpers:
         start_time = time.monotonic()
         raw = self.make_array(buffer, config)
 
-        camera = Picamera2Camera(config, metadata)
+        camera = Picamera2Camera(config.copy(), metadata)
         r = PICAM2DNG(camera)
 
         dng_compress_level = self.picam2.options.get("compress_level", 0)


### PR DESCRIPTION
PiDNG is modifying the raw stream configuration that we pass to it, adding a 'bpp' field that can subsequently cause Picamera2 to fall over. So instead we need to pass it a copy of the raw stream configuration.