### PR TITLE
Add the ability to stop the camera quickly

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1060,7 +1060,7 @@ class Picamera2:
         # to stop, otherwise we can stop directly. When running a proper Qt app, _preview
         # is unset because we expect this code to be running the the Qt thread.
         if self._preview is not None and self._event_loop_running:
-            self.dispatch_functions([self.stop_], wait=True)
+            self.dispatch_functions([self.stop_], wait=True, immediate=True)
         else:
             self.stop_()
 
@@ -1216,7 +1216,7 @@ class Picamera2:
     def switch_mode(self, camera_config, wait=None, signal_function=None):
         """Switch the camera into another mode given by the camera_config."""
         functions = [partial(self.switch_mode_, camera_config)]
-        return self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
     def switch_mode_and_capture_file(self, camera_config, file_output, name="main", format=None,
                                      wait=None, signal_function=None):
@@ -1233,7 +1233,7 @@ class Picamera2:
 
         functions = [partial(self.switch_mode_, camera_config),
                      partial(capture_and_switch_back_, self, file_output, preview_config, format)]
-        return self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
     def switch_mode_and_capture_request(self, camera_config, wait=None, signal_function=None):
         """Switch the camera into a new (capture) mode and capture a request, then switch back.
@@ -1251,7 +1251,7 @@ class Picamera2:
 
         functions = [partial(self.switch_mode_, camera_config),
                      partial(capture_and_switch_back_, self, preview_config)]
-        return self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
     def capture_request_(self):
         # The "use" of this request is transferred from the completed_requests list to the caller.
@@ -1280,7 +1280,7 @@ class Picamera2:
 
         functions = [partial(self.switch_mode_, camera_config),
                      partial(capture_request_and_stop_, self)]
-        return self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
     def capture_metadata_(self):
         if not self.completed_requests:
@@ -1333,7 +1333,7 @@ class Picamera2:
 
         functions = [partial(self.switch_mode_, camera_config),
                      partial(capture_buffer_and_switch_back_, self, preview_config, name)]
-        return self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
     def switch_mode_and_capture_buffers(self, camera_config, names=["main"], wait=None, signal_function=None):
         """Switch the camera into a new (capture) mode, capture the first buffers.
@@ -1349,7 +1349,7 @@ class Picamera2:
 
         functions = [partial(self.switch_mode_, camera_config),
                      partial(capture_buffers_and_switch_back_, self, preview_config, names)]
-        return self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
     def capture_array_(self, name):
         if not self.completed_requests:
@@ -1389,7 +1389,7 @@ class Picamera2:
 
         functions = [partial(self.switch_mode_, camera_config),
                      partial(capture_array_and_switch_back_, self, preview_config, name)]
-        return self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
     def switch_mode_and_capture_arrays(self, camera_config, names=["main"], wait=None, signal_function=None):
         """Switch the camera into a new (capture) mode, capture the image arrays.
@@ -1405,7 +1405,7 @@ class Picamera2:
 
         functions = [partial(self.switch_mode_, camera_config),
                      partial(capture_arrays_and_switch_back_, self, preview_config, names)]
-        return self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
     def capture_image_(self, name: str) -> Image:
         """Capture image
@@ -1449,7 +1449,7 @@ class Picamera2:
 
         functions = [partial(self.switch_mode_, camera_config),
                      partial(capture_image_and_switch_back_, self, preview_config, name)]
-        return self.dispatch_functions(functions, wait, signal_function)
+        return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
     def start_encoder(self, encoder=None, output=None, pts=None, quality=Quality.MEDIUM) -> None:
         """Start encoder

--- a/tests/stop_slow_framerate.py
+++ b/tests/stop_slow_framerate.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+import time
+
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+config = picam2.create_preview_configuration(
+    controls={'FrameRate': 0.2, 'ExposureTime': 5000, 'AnalogueGain': 1.0, 'ColourGains': (1, 1)})
+picam2.configure(config)
+picam2.start()
+
+md = picam2.capture_metadata()
+t0 = time.clock_gettime(time.CLOCK_REALTIME)
+md = picam2.capture_metadata()
+t1 = time.clock_gettime(time.CLOCK_REALTIME)
+print("Frame took", t1 - t0, "seconds")
+if t1 - t0 < 4:
+    print("ERROR: frame arrived too quickly", t1 - t0, "seconds")
+
+picam2.stop()
+t2 = time.clock_gettime(time.CLOCK_REALTIME)
+print("Stopping took", t2 - t1, "seconds")
+if t2 - t1 > 0.5:
+    print("ERROR: stop took too long", t2 - t1, "seconds")

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -63,3 +63,4 @@ tests/preview_cycle_test.py
 tests/preview_location_test.py
 tests/preview_start_stop.py
 tests/qt_gl_preview_test.py
+tests/stop_slow_framerate.py


### PR DESCRIPTION
Currently, stopping the camera requires you to wait for a frame to arrive which can be slow when taking long exposures. This set of commits implements this feature by allowing the event loop to be "prodded" immediately so that prcoess_requests() runs straight away, allowing us to stop the camera.

Although there are quite a few commits, each is trying to make just a small self-contained change towards the end goal. The commits are:

1. Currently process_requests() will bail out if no new requests have arrived. This first change merely makes it run through successfully (doing nothing) if that happens.
2. When a list of "jobs" has been queued up for process_requests() to execute, they're ignored unless there are completed requests available. This change removes this restriction (as stopping the camera will be something we want to happen even if there are no requests). As a side effect, all the functions that jobs currently call need to check for the presence of requests and say that they must "try again later" in that case.
3. This commit causes the event loop (therefore process_requests()) to run immediately if it looks like the job might complete immediately (i.e. there's a completed request waiting already, and the job is the only one in the queue). We also add a flag to force the "prod the event loop immediately" behaviour as we'll need that in due course.
4. The mechanism added in 3 makes the existing mechanism for doing this (the execute_or_dispatch function) redundant, so I've removed that in favour of the new version.
5. Finally, all the jobs that start by stopping the camera (including anything that starts with a mode switch) are updated to prod the event loop immediately, so they should happen instantly.
6. This commit is a test that checks we can indeed stop the camera instantly even when a long exposure is running.