### PR TITLE
Don't allow a Qt widget to try and create a second event loop

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -481,6 +481,8 @@ class Picamera2:
         return self.sensor_modes_
 
     def attach_preview(self, preview) -> None:
+        if self._preview:
+            raise RuntimeError("Preview is already running")
         self._preview = preview
         self._event_loop_running = True
 


### PR DESCRIPTION
If Picamera2 has already been started it will be running an event loop. Creating a Picamera2 Qt widget would now create a second event loop, leading to undesired behaviour. Instead, just raise an error. The Qt widget should be created before starting the camera.