### PR TITLE
previews: Overlays won't work in DRM/QTGL previews if buffer_count is 1

### DIFF
--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -300,6 +300,8 @@ class QGlPicamera2(QWidget):
     def set_overlay(self, overlay):
         if self.picamera2.camera_config is None:
             raise RuntimeError("Camera must be configured before setting overlay")
+        if self.picamera2.camera_config['buffer_count'] < 2:
+            raise RuntimeError("Need at least buffer_count=2 to set overlay")
 
         with self.lock:
             eglMakeCurrent(self.egl.display, self.surface, self.surface, self.egl.context)


### PR DESCRIPTION
These preview types normally hold on to their last image buffer, except that they can't do this when the system is running is with only a single buffer. In this case, trying to redraw everything with a new overlay is likely to fail, so instead we are going to insist on having at least two buffers.