### PR TITLE
H264 encoder quality was having no effect on bitrate

### DIFF
--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -69,7 +69,7 @@ class H264Encoder(V4L2Encoder):
         super()._start()
 
     def _setup(self, quality):
-        if getattr(self, "bitrate", None) is None and getattr(self, "qt", None) is not None:
+        if getattr(self, "bitrate", None) is None and getattr(self, "qp", None) is None:
             # These are suggested bitrates for 1080p30 in Mbps
             BITRATE_TABLE = {Quality.VERY_LOW: 2,
                              Quality.LOW: 4,

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1448,7 +1448,7 @@ class Picamera2:
                      partial(capture_image_and_switch_back_, self, preview_config, name)]
         return self.dispatch_functions(functions, wait, signal_function, immediate=True)
 
-    def start_encoder(self, encoder=None, output=None, pts=None, quality=Quality.MEDIUM, name=None) -> None:
+    def start_encoder(self, encoder=None, output=None, pts=None, quality=None, name=None) -> None:
         """Start encoder
 
         :param encoder: Sets encoder or uses existing, defaults to None
@@ -1488,6 +1488,12 @@ class Picamera2:
         except AttributeError:
             pass
         # Finally the encoder must set up any remaining unknown parameters (e.g. bitrate).
+        if quality is not None:
+            # Override any bitrate if a quality was explicitly given.
+            _encoder.bitrate = None
+        else:
+            # Otherwise default to medium, though any preset bitrate will take precedence.
+            quality = Quality.MEDIUM
         _encoder._setup(quality)
         _encoder.start()
         with self.lock:
@@ -1535,7 +1541,7 @@ class Picamera2:
         else:
             raise RuntimeError("Must pass Encoder or set of")
 
-    def start_recording(self, encoder, output, pts=None, config=None, quality=Quality.MEDIUM, name=None) -> None:
+    def start_recording(self, encoder, output, pts=None, config=None, quality=None, name=None) -> None:
         """Start recording a video using the given encoder and to the given output.
 
         Output may be a string in which case the correspondingly named file is opened.

--- a/tests/bitrate_check.py
+++ b/tests/bitrate_check.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+
+# Check that specifying a quality causes a pre-existing bitrate to be overwritten,
+# but that it stays the same when no quality is given.
+
+import time
+
+from picamera2 import Picamera2
+from picamera2.encoders import H264Encoder, Quality
+
+picam2 = Picamera2()
+video_config = picam2.create_video_configuration()
+picam2.configure(video_config)
+encoder = H264Encoder()
+
+picam2.start_recording(encoder, 'low.h264', quality=Quality.VERY_LOW)
+bitrate_low = encoder.bitrate
+time.sleep(5)
+picam2.stop_recording()
+
+picam2.start_recording(encoder, 'high.h264', quality=Quality.HIGH)
+bitrate_high = encoder.bitrate
+time.sleep(5)
+picam2.stop_recording()
+
+picam2.start_recording(encoder, 'high_again.h264')
+bitrate_high_again = encoder.bitrate
+time.sleep(5)
+picam2.stop_recording()
+
+# Now, it should be that the bitrate increased from the first recording to
+# the second, but stayed the same for the third.
+
+print(bitrate_low, bitrate_high, bitrate_high_again)
+if bitrate_low >= bitrate_high or bitrate_high != bitrate_high_again:
+    print("Error: bitrates not as expected")

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -47,6 +47,7 @@ tests/app_full_test.py
 tests/app_test.py
 tests/autofocus_test.py
 tests/async_test.py
+tests/bitrate_check.py
 tests/check_timestamps.py
 tests/close_test.py
 tests/close_test_multiple.py


### PR DESCRIPTION
The quality parameter was being ignored. Code also tweaked so that setting an explicit quality causes any previous bitrate to be overwritten, whereas omitting the quality will leave it alone (or default to medium quality if there was no bitrate set).

A test is also added to check that the bitrate does indeed change as described.