### PR TITLE
Convert tuples of libcamera.Rectangles to non-libcamera types

### DIFF
--- a/picamera2/utils.py
+++ b/picamera2/utils.py
@@ -8,7 +8,7 @@ def convert_from_libcamera_type(value):
         value = (value.x, value.y, value.width, value.height)
     elif isinstance(value, Size):
         value = (value.width, value.height)
-    elif isinstance(value, list) and all(isinstance(item, Rectangle) for item in value):
+    elif isinstance(value, (list, tuple)) and all(isinstance(item, Rectangle) for item in value):
         value = [(v.x, v.y, v.width, v.height) for v in value]
     return value
 


### PR DESCRIPTION
Previously it was converting lists of them, but not tuples.