### PR TITLE
previews: make stop_preview() wait for them to finish completely

### DIFF
--- a/tests/preview_start_stop.py
+++ b/tests/preview_start_stop.py
@@ -4,37 +4,31 @@ import time
 
 from picamera2 import Picamera2, Preview
 
-
-def click_close_button():
-    # Nasty hack just for testing, emulate clicking the window close button
-    picam2._preview.qpicamera2.close()
-
-
 picam2 = Picamera2()
 
 picam2.start_preview(Preview.QTGL)
 time.sleep(1)
-click_close_button()
+picam2.stop_preview()
 time.sleep(1)
 
 picam2.start_preview(Preview.QTGL)
 time.sleep(1)
-click_close_button()
+picam2.stop_preview()
 time.sleep(1)
 
 picam2.start_preview(Preview.QT)
 time.sleep(1)
-click_close_button()
+picam2.stop_preview()
 time.sleep(1)
 
 picam2.start_preview(Preview.QT)
 time.sleep(1)
-click_close_button()
+picam2.stop_preview()
 time.sleep(1)
 
 picam2.start_preview(Preview.QTGL)
 picam2.start()
 time.sleep(2)
-click_close_button()
+picam2.stop_preview()
 
 picam2.stop()


### PR DESCRIPTION
The Qt previews only dump a message onto the Qt event queue to tell the windows to stop, but they might still do something after stop_preview() has returned. I think we're confident now that we can get our "cleanup" methods to run when these windows close, so we can add an event for them to set once they truly won't do anything more.