### PR TITLE
Use `os.path.expanduser("~")` to safely expand path and rename `dir` in `directory` to avoid `dir()` redefinition (close #733).

### DIFF
--- a/picamera2/__init__.py
+++ b/picamera2/__init__.py
@@ -11,12 +11,16 @@ from .request import CompletedRequest, MappedArray
 
 
 def _set_configuration_file(filename):
-    user = os.environ.get('USER', "pi")
-    dirs = [os.path.join("/home", user, "libcamera/src/libcamera/pipeline/rpi/vc4/data"),
-            "/usr/local/share/libcamera/pipeline/rpi/vc4",
-            "/usr/share/libcamera/pipeline/rpi/vc4"]
-    for dir in dirs:
-        file = os.path.join(dir, filename)
+    dirs = [
+        os.path.expanduser(
+            "~/libcamera/src/libcamera/pipeline/rpi/vc4/data"
+        ),
+        "/usr/local/share/libcamera/pipeline/rpi/vc4",
+        "/usr/share/libcamera/pipeline/rpi/vc4"]
+
+    for directory in dirs:
+        file = os.path.join(directory, filename)
+
         if os.path.isfile(file):
             os.environ['LIBCAMERA_RPI_CONFIG_FILE'] = file
             break


### PR DESCRIPTION
`dir` is a built-in function in Python, so it should not be used as a variable name. This commit renames `dir` to `directory`.

In "Linux", `os.path.expanduser("~")` returns the user's home directory. This avoids using some hack to find the username and stitch it to `/home/` to get the user's home directory. It can be an issue since `/home/<USER>` is not always the user's home directory, see #733 for more details.

P.S.: I was not able to install the `requirements-test.txt` dependencies, so I did not run the tests.