### PR TITLE
Add missing encode format

### DIFF
--- a/picamera2/encoders/encoder.py
+++ b/picamera2/encoders/encoder.py
@@ -146,6 +146,8 @@ class Encoder:
         """
         if value == "RGB888":
             self._format = V4L2_PIX_FMT_BGR24
+        elif value == "BGR888":
+            self._format = V4L2_PIX_FMT_RGB24
         elif value == "YUV420":
             self._format = V4L2_PIX_FMT_YUV420
         elif value == "XBGR8888":

--- a/tests/easy_video2.py
+++ b/tests/easy_video2.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+
+# This format was missing previously:
+picam2.video_configuration.format = 'BGR888'
+
+# Record a 2 second video.
+picam2.start_and_record_video("test.mp4", duration=2)

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -56,6 +56,7 @@ tests/configurations.py
 tests/context_test.py
 tests/display_transform_null.py
 tests/display_transform_qt.py
+tests/easy_video2.py
 tests/encoder_start_stop.py
 tests/large_datagram.py
 tests/mjpeg_server.py


### PR DESCRIPTION
The BGR888 format seemed to be missing.

Also add a test that uses it so that it can't go missing again.