### PR TITLE
Fix for PIL version 10

### DIFF
--- a/picamera2/previews/q_picamera2.py
+++ b/picamera2/previews/q_picamera2.py
@@ -188,7 +188,8 @@ class QPicamera2(QGraphicsView):
         width = min(img.shape[1], stream_config["size"][0])
         width -= width % 4
         img = np.ascontiguousarray(img[:, :width, :3])
-        qim = QImage(img.data, width, img.shape[0], QImage.Format_RGB888)
+        fmt = QImage.Format_BGR888 if stream_config['format'] in ('RGB888', 'XRGB8888') else QImage.Format_RGB888
+        qim = QImage(img.data, width, img.shape[0], fmt)
         pix = QPixmap(qim)
         # Add the pixmap to the scene if there wasn't one, or replace it if the images have
         # changed size.

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -228,7 +228,7 @@ class Helpers:
             return Image.open(io.BytesIO(buffer))
         else:
             rgb = self.make_array(buffer, config)
-        mode_lookup = {"RGB888": "BGR", "BGR888": "RGB", "XBGR8888": "RGBA", "XRGB8888": "BGRX"}
+        mode_lookup = {"RGB888": "BGR", "BGR888": "RGB", "XBGR8888": "RGBX", "XRGB8888": "BGRX"}
         if fmt not in mode_lookup:
             raise RuntimeError(f"Stream format {fmt} not supported for PIL images")
         mode = mode_lookup[fmt]
@@ -255,11 +255,11 @@ class Helpers:
             format_str = file_output.suffix.lower()
         else:
             raise RuntimeError("Cannot determine format to save")
+        if format_str in ('png') and img.mode == 'RGBX':
+            # It seems we can't save an RGBX png file, so make it RGBA instead. We can't use RGBA
+            # everywhere, because we can only save an RGBX jpeg, not an RGBA one.
+            img = img.convert(mode='RGBA')
         if format_str in ('jpg', 'jpeg'):
-            if img.mode == "RGBA":
-                # Nasty hack. Qt doesn't understand RGBX so we have to use RGBA. But saving a JPEG
-                # doesn't like RGBA to we have to bodge that to RGBX.
-                img.mode = "RGBX"
             # Make up some extra EXIF data.
             if "AnalogueGain" in metadata and "DigitalGain" in metadata:
                 datetime_now = datetime.now().strftime("%Y:%m:%d %H:%M:%S")


### PR DESCRIPTION
You can no longer do:

img.mode = 'RGBX'

but the alternative:

img = img.convert(mode='RGBX')

seems to work on older PIL versions, so we'll go with that.