### PR TITLE
Make camera configuration objects work properly with sensor configuration

### DIFF
--- a/picamera2/configuration.py
+++ b/picamera2/configuration.py
@@ -88,10 +88,17 @@ class StreamConfiguration(Configuration):
     _FORWARD_FIELDS = {}
 
 
+class SensorConfiguration(Configuration):
+    _ALLOWED_FIELDS = ("output_size", "bit_depth")
+    _FIELD_CLASS_MAP = {}
+    _FORWARD_FIELDS = {}
+
+
 class CameraConfiguration(Configuration):
     _ALLOWED_FIELDS = ("use_case", "buffer_count", "transform", "display", "encode", "colour_space",
                        "controls", "main", "lores", "raw", "queue", "sensor")
-    _FIELD_CLASS_MAP = {"main": StreamConfiguration, "lores": StreamConfiguration, "raw": StreamConfiguration}
+    _FIELD_CLASS_MAP = {"main": StreamConfiguration, "lores": StreamConfiguration, "raw": StreamConfiguration,
+                        "sensor": SensorConfiguration}
     _FORWARD_FIELDS = {"size": "main", "format": "main"}
 
     def __init__(self, d={}, picam2=None):
@@ -102,6 +109,8 @@ class CameraConfiguration(Configuration):
         # can delete the raw stream if they wish.
         if 'raw' not in d:
             self.enable_raw()
+        if 'sensor' not in d:
+            self.sensor = SensorConfiguration()
 
     def enable_lores(self, onoff=True):
         if onoff:

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -878,7 +878,8 @@ class Picamera2:
 
         # We're always going to set up the sensor config fully.
         bit_depth = 0
-        if 'bit_depth' in camera_config['sensor']:
+        if camera_config['sensor'] is not None and 'bit_depth' in camera_config['sensor'] and \
+           camera_config['sensor']['bit_depth'] is not None:
             bit_depth = camera_config['sensor']['bit_depth']
         elif 'raw' in camera_config and camera_config['raw'] is not None and 'format' in camera_config['raw']:
             bit_depth = SensorFormat(camera_config['raw']['format']).bit_depth
@@ -886,7 +887,8 @@ class Picamera2:
             bit_depth = SensorFormat(self.sensor_format).bit_depth
 
         output_size = None
-        if 'output_size' in camera_config['sensor']:
+        if camera_config['sensor'] is not None and 'output_size' in camera_config['sensor'] and \
+           camera_config['sensor']['output_size'] is not None:
             output_size = camera_config['sensor']['output_size']
         elif 'raw' in camera_config and camera_config['raw'] is not None and 'size' in camera_config['raw']:
             output_size = camera_config['raw']['size']

--- a/tests/config_with_sensor.py
+++ b/tests/config_with_sensor.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+# This test uses the configuration object idiom to set up the camera configuration,
+# but we additionally exercise the behaviour of the SensorConfiguration object
+# inside the CameraConfiguration.
+
+# The camera mode chosen should follow the sensor configuration if that's there,
+# otherwise the raw stream configuration.
+
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+
+max_mode = None
+min_mode = None
+for mode in picam2.sensor_modes:
+    if max_mode is None or mode['size'] > max_mode['size']:
+        max_mode = mode
+    if min_mode is None or mode['size'] < min_mode['size']:
+        min_mode = mode
+
+print("Biggest mode:", max_mode)
+print("Smallest mode:", min_mode)
+
+if max_mode['size'] != min_mode['size']:
+
+    picam2.still_configuration.main.size = min_mode['size']
+    picam2.still_configuration.raw.size = min_mode['size']
+    picam2.still_configuration.raw.format = min_mode['format'].format
+
+    picam2.configure("still")
+
+    # Check we got the config we wanted.
+    config = picam2.camera_configuration()
+
+    if config['main']['size'] != min_mode['size']:
+        print("ERROR: main stream size mismatch")
+
+    if config['raw']['size'] != min_mode['size']:
+        print("ERROR: raw stream size mismatch")
+
+    # Now change the main and raw stream sizes.
+    picam2.still_configuration.main.size = max_mode['size']
+    picam2.still_configuration.raw.size = max_mode['size']
+    picam2.still_configuration.raw.format = max_mode['format'].format
+
+    picam2.configure("still")
+
+    # The main stream size should change, but the raw stream size should be the same as before,
+    # because we haven't updated the sensor config.
+    config = picam2.camera_configuration()
+
+    if config['main']['size'] != max_mode['size']:
+        print("ERROR: main stream size mismatch")
+
+    if config['raw']['size'] != min_mode['size']:
+        print("ERROR: raw stream size changed unexpectedly")
+
+    if picam2.still_configuration.raw.size != picam2.still_configuration.sensor.output_size:
+        print("ERROR: raw stream and sensor sizes should match")
+
+    # Now update the sensor config, and the raw stream should change too.
+    picam2.still_configuration.sensor.output_size = max_mode['size']
+    picam2.still_configuration.sensor.bit_depth = max_mode['format'].bit_depth
+
+    picam2.configure("still")
+    config = picam2.camera_configuration()
+
+    if config['main']['size'] != max_mode['size']:
+        print("ERROR: main stream size mismatch")
+
+    if config['raw']['size'] != max_mode['size']:
+        print("ERROR: raw stream has not updated")
+
+    if picam2.still_configuration.raw.size != picam2.still_configuration.sensor.output_size:
+        print("ERROR: raw stream and sensor sizes should match")
+
+    # Final test. Let's check we can clear the sensor config out, and it will obey the
+    # raw stream config again. No change to the main stream.
+    picam2.still_configuration.sensor = None
+    picam2.still_configuration.raw.size = min_mode['size']
+    picam2.still_configuration.raw.format = min_mode['format'].format
+
+    picam2.configure("still")
+    config = picam2.camera_configuration()
+
+    if config['main']['size'] != max_mode['size']:
+        print("ERROR: main stream size mismatch")
+
+    if config['raw']['size'] != min_mode['size']:
+        print("ERROR: raw stream has been ignored")
+
+    if picam2.still_configuration.raw.size != picam2.still_configuration.sensor.output_size:
+        print("ERROR: raw stream and sensor sizes should match")
+
+    # Actually, one more thing. Let's overwrite the sensor config in the current camera
+    # config and check that the raw stream changes again. Currently it's "min_mode".
+
+    config = picam2.camera_configuration()
+    config['sensor'] = {'output_size': max_mode['size'], 'bit_depth': max_mode['format'].bit_depth}
+    picam2.configure(config)
+
+    config = picam2.camera_configuration()
+    if config['raw']['size'] != max_mode['size']:
+        print("ERROR: raw stream has been ignored")

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -53,6 +53,7 @@ tests/close_test.py
 tests/close_test_multiple.py
 tests/codecs.py
 tests/colour_spaces.py
+tests/config_with_sensor.py
 tests/configurations.py
 tests/context_test.py
 tests/display_transform_null.py


### PR DESCRIPTION
You can now set the `sensor.output_size` and `sensor.bit_depth` in the camera config object. You can also set it to `None` so that any raw stream parameters will take precendence.
