### PR TITLE
Fix occasional leak of CompletedRequest buffers

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1170,7 +1170,10 @@ class Picamera2:
             self._cm.handle_request(self.camera_idx)
             self.started = False
             with self._requestslock:
+                unseen_requests = self._requests
                 self._requests = []
+            for r in unseen_requests:
+                r.release()
             while len(self.completed_requests) > 0:
                 self.completed_requests.pop(0).release()
             self.completed_requests = []

--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -129,7 +129,7 @@ class CompletedRequest:
             elif self.ref_count == 0:
                 # If the camera has been stopped since this request was returned then we
                 # can't recycle it.
-                if self.picam2.camera and self.stop_count == self.picam2.stop_count:
+                if self.picam2.camera and self.stop_count == self.picam2.stop_count and self.picam2.started:
                     self.request.reuse()
                     controls = self.picam2.controls.get_libcamera_controls()
                     for id, value in controls.items():


### PR DESCRIPTION
There was a small window of opportunity between a CompletedRequest being made in the thread that services camera manager events, and the threads that service requests on behalf of each camera, where the "release" call was not happening.