### PR TITLE
Fix DmaAllocator memory leak when closing camera

### DIFF
--- a/picamera2/allocators/allocator.py
+++ b/picamera2/allocators/allocator.py
@@ -16,6 +16,9 @@ class Allocator:
     def release(self, bufs):
         pass
 
+    def close(self):
+        pass
+
 
 class Sync:
     """Base class for allocator syncronisations"""

--- a/picamera2/allocators/dmaallocator.py
+++ b/picamera2/allocators/dmaallocator.py
@@ -87,6 +87,18 @@ class DmaAllocator(Allocator):
         for k in [k for k, v in self.mapped_buffers.items() if v.closed]:
             del self.mapped_buffers[k]
 
+    def close(self):
+        self.libcamera_fds = []
+        self.cleanup()
+        # Close our copies of fds
+        for fd in self.open_fds:
+            os.close(fd)
+        self.frame_buffers = {}
+        self.open_fds = []
+
+    def __del__(self):
+        self.close()
+
     class DmaSync(Sync):
         """Dma Buffer Sync"""
 

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -22,7 +22,7 @@ from PIL import Image
 import picamera2.formats as formats
 import picamera2.platform as Platform
 import picamera2.utils as utils
-from picamera2.allocators import DmaAllocator
+from picamera2.allocators import Allocator, DmaAllocator
 from picamera2.encoders import Encoder, H264Encoder, MJPEGEncoder, Quality
 from picamera2.outputs import FfmpegOutput, FileOutput
 from picamera2.previews import DrmPreview, NullPreview, QtGlPreview, QtPreview
@@ -622,6 +622,9 @@ class Picamera2:
         self.video_configuration_ = None
         self.notifymeread.close()
         os.close(self.notifyme_w)
+        # Clean up the allocator
+        del self.allocator
+        self.allocator = Allocator()
         _log.info('Camera closed successfully.')
 
     @staticmethod

--- a/tests/allocator_leak_test.py
+++ b/tests/allocator_leak_test.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+
+# Test that the allocators don't leak
+
+from picamera2 import Picamera2
+from picamera2.allocators import DmaAllocator, LibcameraAllocator
+
+for _ in range(20):
+    picam2 = Picamera2()
+    picam2.allocator = LibcameraAllocator(picam2.camera)
+    picam2.configure("still")
+    picam2.close()
+
+for _ in range(20):
+    picam2 = Picamera2()
+    picam2.allocator = DmaAllocator()
+    picam2.configure("still")
+    picam2.close()

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -76,3 +76,4 @@ tests/quality_check.py
 tests/qt_gl_preview_test.py
 tests/stop_slow_framerate.py
 tests/allocator_test.py
+tests/allocator_leak_test.py


### PR DESCRIPTION
When closing the camera, the allocator was not closing the open file descriptors, causing a memory leak. Fixed by closing the file descriptors and deleting the allocator when closing the camera.

Fixes #887 