### PR TITLE
Add timeout support when waiting for asynchronous request to finish

### DIFF
--- a/picamera2/job.py
+++ b/picamera2/job.py
@@ -70,10 +70,10 @@ class Job:
         if self._signal_function:
             self._signal_function(self)
 
-    def get_result(self):
+    def get_result(self, timeout=None):
         """This fetches the 'final result' of the job
 
         (being given by the return value of the last function executed). It will block
         if necessary for the job to complete.
         """
-        return self._future.result()
+        return self._future.result(timeout=timeout)

--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1277,14 +1277,14 @@ class Picamera2:
         """Cause the process_requests method to run in the event loop again."""
         os.write(self.notifyme_w, b"\x00")
 
-    def wait(self, job):
+    def wait(self, job, timeout=None):
         """Wait for the given job to finish (if necessary) and return its final result.
 
         The job is obtained either by calling one of the Picamera2 methods asynchronously
         (passing wait=False), or as a parameter to the signal_function that can be
         supplied to those same methods.
         """
-        return job.get_result()
+        return job.get_result(timeout=timeout)
 
     def dispatch_functions(self, functions, wait, signal_function=None, immediate=False) -> None:
         """The main thread should use this to dispatch a number of operations for the event loop to perform.


### PR DESCRIPTION
Waiting for a "job" to finish lets you specify a timeout. A TimeoutError is raised if the timeout occurs. Note that this doesn't "cancel" the job in any way.

You can also pas a timeout of zero simply to poll for whether the job has completed.