### PR TITLE
Add Persistent Allocator

### DIFF
--- a/examples/switch_mode_persist.py
+++ b/examples/switch_mode_persist.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+
+# Switch between modes without reallocating buffers.
+
+import time
+
+from picamera2 import Picamera2
+from picamera2.allocators import PersistentAllocator
+
+picam2 = Picamera2(allocator=PersistentAllocator())
+
+# Create preview configuration
+preview_config = picam2.create_preview_configuration()
+picam2.configure(preview_config)
+
+# Create full resolution preview configuration
+full_res_config = picam2.create_preview_configuration(
+    main={"size": picam2.sensor_resolution}, buffer_count=2, use_case="full_res_preview"
+)
+picam2.configure(full_res_config)
+
+# Create still configuration
+still_config = picam2.create_still_configuration()
+picam2.configure(still_config)
+
+# Use preview configuration
+picam2.configure(preview_config)
+picam2.start()
+time.sleep(2)
+picam2.stop()
+
+# Use other configuration
+picam2.configure(full_res_config)
+picam2.start()
+time.sleep(2)
+picam2.stop()
+
+# Back to preview
+picam2.configure(preview_config)
+picam2.start()
+# Delete other buffers to free up space
+picam2.allocator.deallocate("full_res_preview")
+time.sleep(2)
+
+# Capture image with still configuration
+picam2.switch_mode_and_capture_file(still_config, "test.jpg")
+
+time.sleep(1)
+picam2.stop()

--- a/picamera2/allocators/__init__.py
+++ b/picamera2/allocators/__init__.py
@@ -1,3 +1,4 @@
 from .allocator import Allocator
 from .dmaallocator import DmaAllocator
 from .libcameraallocator import LibcameraAllocator
+from .persistent_allocator import PersistentAllocator

--- a/picamera2/allocators/allocator.py
+++ b/picamera2/allocators/allocator.py
@@ -4,7 +4,7 @@ class Allocator:
     def __init__(self):
         self.sync = Sync
 
-    def allocate(self, libcamera_config):
+    def allocate(self, libcamera_config, use_case):
         pass
 
     def buffers(self, stream):

--- a/picamera2/allocators/dmaallocator.py
+++ b/picamera2/allocators/dmaallocator.py
@@ -26,7 +26,7 @@ class DmaAllocator(Allocator):
         self.libcamera_fds = []
         self.sync = self.DmaSync
 
-    def allocate(self, libcamera_config):
+    def allocate(self, libcamera_config, _):
         # Delete old buffers
         self.libcamera_fds = []
         self.cleanup()

--- a/picamera2/allocators/libcameraallocator.py
+++ b/picamera2/allocators/libcameraallocator.py
@@ -14,7 +14,7 @@ class LibcameraAllocator(Allocator):
         super().__init__()
         self.camera = camera
 
-    def allocate(self, libcamera_config):
+    def allocate(self, libcamera_config, _):
         self.allocator = libcamera.FrameBufferAllocator(self.camera)
         streams = [stream_config.stream for stream_config in libcamera_config]
         for i, stream in enumerate(streams):

--- a/picamera2/allocators/persistent_allocator.py
+++ b/picamera2/allocators/persistent_allocator.py
@@ -1,0 +1,59 @@
+import logging
+
+from picamera2.allocators import DmaAllocator
+
+_log = logging.getLogger("picamera2")
+
+
+class PersistentAllocator(DmaAllocator):
+    """Persistent DmaHeap Allocator"""
+
+    def __init__(self):
+        super().__init__()
+        self.buffer_key = None
+        self.buffer_dict = {}
+
+    def allocate(self, libcamera_config, use_case):
+        if use_case is None:
+            _log.error("Must set use_case before using persistent allocator")
+        self.buffer_key = use_case
+
+        self.open_fds = []
+        self.libcamera_fds = []
+        self.frame_buffers = {}
+        self.mapped_buffers = {}
+        self.mapped_buffers_used = {}
+
+        buffers = self.buffer_dict.get(self.buffer_key)
+        if buffers is None:
+            super().allocate(libcamera_config, use_case)
+            self.buffer_dict[self.buffer_key] = (
+                self.open_fds,
+                self.libcamera_fds,
+                self.frame_buffers,
+                self.mapped_buffers,
+                self.mapped_buffers_used,
+            )
+        else:
+            (self.open_fds, self.libcamera_fds, self.frame_buffers,
+             self.mapped_buffers, self.mapped_buffers_used) = buffers
+
+    def cleanup(self):
+        pass
+
+    def deallocate(self, buffer_key=None):
+        """Deallocate a set of buffers if no longer in use"""
+        if buffer_key is None:
+            buffer_key = self.buffer_key
+
+        tmp = super().__new__(DmaAllocator)
+
+        (tmp.open_fds, tmp.libcamera_fds, tmp.frame_buffers,
+         tmp.mapped_buffers, tmp.mapped_buffers_used) = self.buffer_dict[buffer_key]
+        tmp.close()
+        del self.buffer_dict[buffer_key]
+
+    def close(self):
+        for k in list(self.buffer_dict.keys()):
+            self.deallocate(k)
+        assert self.buffer_dict == {}

--- a/tests/allocator_leak_test.py
+++ b/tests/allocator_leak_test.py
@@ -3,7 +3,8 @@
 # Test that the allocators don't leak
 
 from picamera2 import Picamera2
-from picamera2.allocators import DmaAllocator, LibcameraAllocator
+from picamera2.allocators import (DmaAllocator, LibcameraAllocator,
+                                  PersistentAllocator)
 
 for _ in range(20):
     picam2 = Picamera2()
@@ -15,4 +16,13 @@ for _ in range(20):
     picam2 = Picamera2()
     picam2.allocator = DmaAllocator()
     picam2.configure("still")
+    picam2.close()
+
+for _ in range(20):
+    picam2 = Picamera2()
+    picam2.allocator = PersistentAllocator()
+    picam2.allocator.buffer_key = "still"
+    picam2.configure("still")
+    picam2.allocator.buffer_key = "preview"
+    picam2.configure("preview")
     picam2.close()

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -37,6 +37,7 @@ examples/still_capture_with_config.py
 examples/still_during_video.py
 examples/switch_mode.py
 examples/switch_mode_2.py
+examples/switch_mode_persist.py
 examples/timestamp_capture.py
 examples/title_bar.py
 examples/tuning_file.py


### PR DESCRIPTION
Add a variant of the DmaAllocator where the buffers are not deallocated after switching mode, allowing you to have multiple sets of buffers stored which can be switched between based on the camera configuration. It selects which buffers to use for a given configuration based off the use_case parameter, so this must be set uniquely for each configuration that will be used with the allocator.