### PR TITLE
Add support for h.264 codec profiles

### DIFF
--- a/picamera2/encoders/libav_h264_encoder.py
+++ b/picamera2/encoders/libav_h264_encoder.py
@@ -13,7 +13,7 @@ from ..request import MappedArray
 class LibavH264Encoder(Encoder):
     """Encoder class that uses libx264 for h.264 encoding."""
 
-    def __init__(self, bitrate=None, repeat=True, iperiod=30, framerate=30, qp=None):
+    def __init__(self, bitrate=None, repeat=True, iperiod=30, framerate=30, qp=None, profile=None):
         """Initialise"""
         super().__init__()
         self._codec = "h264"  # for now only support h264
@@ -22,6 +22,8 @@ class LibavH264Encoder(Encoder):
         self.iperiod = iperiod
         self.framerate = framerate
         self.qp = qp
+        self.profile = profile
+        self.preset = None
 
     def _setup(self, quality):
         # If an explicit quality was specified, use it, otherwise try to preserve any bitrate/qp
@@ -45,20 +47,39 @@ class LibavH264Encoder(Encoder):
         self._stream = self._container.add_stream(self._codec, rate=self.framerate)
 
         self._stream.codec_context.thread_count = 8
-        self._stream.codec_context.thread_type = av.codec.context.ThreadType.FRAME
+        self._stream.codec_context.thread_type = av.codec.context.ThreadType.FRAME  # noqa
 
         self._stream.width = self.width
         self._stream.height = self.height
         self._stream.pix_fmt = "yuv420p"
 
+        preset = "ultrafast"
+        if self.profile is not None:
+            if not isinstance(self.profile, str):
+                raise RuntimeError("Profile should be a string value")
+            # Much more helpful to compare profile names case insensitively!
+            available_profiles = {k.lower(): v for k, v in self._stream.codec.profiles.items()}
+            profile = self.profile.lower()
+            if profile not in available_profiles:
+                raise RuntimeError("Profile " + self.profile + " not recognised")
+            self._stream.codec_context.profile = available_profiles[profile]
+            # The "ultrafast" preset always produces baseline, so:
+            if "baseline" not in profile:
+                preset = "superfast"
+
         if self.bitrate is not None:
             self._stream.codec_context.bit_rate = self.bitrate
         self._stream.codec_context.gop_size = self.iperiod
-        self._stream.codec_context.options["preset"] = "ultrafast"
+
+        # For those who know what they're doing, let them override the "preset".
+        if self.preset:
+            preset = self.preset
+        self._stream.codec_context.options["preset"] = preset
+
         self._stream.codec_context.options["deblock"] = "1"
         # Absence of the "global header" flags means that SPS/PPS headers get repeated.
         if not self.repeat:
-            self._stream.codec_context.flags |= av.codec.context.Flags.GLOBAL_HEADER
+            self._stream.codec_context.flags |= av.codec.context.Flags.GLOBAL_HEADER  # noqa
         if self.qp is not None:
             self._stream.codec_context.qmin = self.qp
             self._stream.codec_context.qmax = self.qp


### PR DESCRIPTION
Both hardware and libav h.264 encoders are updated. The hardware will support baseline, constrained baseline, main and high. libav will support, well, what libav supports (which is a much wider selection).

libav users can also change the encoder "preset" for higher quality encode when there is sufficient CPU available.