### PR TITLE
Close DmaHeap when closing DmaAllocator

### DIFF
--- a/picamera2/allocators/dmaallocator.py
+++ b/picamera2/allocators/dmaallocator.py
@@ -95,6 +95,8 @@ class DmaAllocator(Allocator):
             os.close(fd)
         self.frame_buffers = {}
         self.open_fds = []
+        if self.dmaHeap is not None:
+            self.dmaHeap.close()
 
     def __del__(self):
         self.close()

--- a/picamera2/allocators/persistent_allocator.py
+++ b/picamera2/allocators/persistent_allocator.py
@@ -47,6 +47,7 @@ class PersistentAllocator(DmaAllocator):
             buffer_key = self.buffer_key
 
         tmp = super().__new__(DmaAllocator)
+        tmp.dmaHeap = None
 
         (tmp.open_fds, tmp.libcamera_fds, tmp.frame_buffers,
          tmp.mapped_buffers, tmp.mapped_buffers_used) = self.buffer_dict[buffer_key]

--- a/picamera2/dma_heap.py
+++ b/picamera2/dma_heap.py
@@ -107,3 +107,6 @@ class DmaHeap:
             return UniqueFD()
 
         return allocFd
+
+    def close(self):
+        os.close(self.__dmaHeapHandle.get())


### PR DESCRIPTION
The DmaHeap file descriptor wasn't being closed when the DmaAllocator was closed, resulting in a leak of file descriptors.