### PR TITLE
Deprecate use of the ScalerCropMaximum property

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -499,7 +499,7 @@ class Picamera2:
                 self.configure(temp_config)
                 frameDurationMin = self.camera_controls["FrameDurationLimits"][0]
                 cam_mode["fps"] = round(1e6 / frameDurationMin, 2)
-                cam_mode["crop_limits"] = self.camera_properties["ScalerCropMaximum"]
+                cam_mode["crop_limits"] = utils.convert_from_libcamera_type(self.camera_ctrl_info['ScalerCrop'][1].max)
                 cam_mode["exposure_limits"] = tuple([i for i in self.camera_controls["ExposureTime"] if i != 0])
                 self.sensor_modes_.append(cam_mode)
         return self.sensor_modes_

--- a/tests/autofocus_test.py
+++ b/tests/autofocus_test.py
@@ -2,7 +2,7 @@ import time
 
 from libcamera import controls
 
-from picamera2 import Picamera2
+from picamera2 import Picamera2, utils
 
 picam2 = Picamera2()
 if 'AfMode' not in picam2.camera_controls:
@@ -94,6 +94,6 @@ picam2.set_controls({'AfMetering': controls.AfMeteringEnum.Windows})
 time.sleep(0.1)
 
 print("Test AfWindows")
-max_window = picam2.camera_properties['ScalerCropMaximum']
+max_window = utils.convert_from_libcamera_type(picam2.camera_ctrl_info['ScalerCrop'][1].max)
 picam2.set_controls({'AfWindows': [max_window]})
 time.sleep(0.1)


### PR DESCRIPTION
This will be dropped by libcamera. Instead, use the maximum value of the ScalerCrop control, which stores an identical rectangle.