### PR TITLE
Fix EGL related memory leak

### DIFF
--- a/picamera2/previews/q_gl_picamera2.py
+++ b/picamera2/previews/q_gl_picamera2.py
@@ -131,6 +131,13 @@ class QGlPicamera2(QWidget):
         if self.preview_window is not None:  # will be none when a proper Qt app
             self.preview_window.qpicamera2 = None
 
+        # Some extra EGL cleanup seems to be required.
+        for (_, buffer) in self.buffers.items():
+            glDeleteTextures(1, [buffer.texture])
+        self.buffers = {}
+        eglDestroyContext(self.egl.display, self.egl.context)
+        self.egl.context = None
+
     def closeEvent(self, event):
         self.cleanup()
 

--- a/tests/egl_leak.py
+++ b/tests/egl_leak.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+# Opening and closing the QTGL preview was leaking buffer handles.
+
+import subprocess
+import time
+
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+half_res = tuple([s // 2 for s in picam2.sensor_resolution])
+
+for _ in range(10):
+    subprocess.check_call(['grep', 'Cma', '/proc/meminfo'])
+    config = picam2.create_preview_configuration({'size': half_res}, raw={'size': half_res})
+    picam2.configure(config)
+    picam2.start(show_preview=True)
+    time.sleep(1)
+    picam2.stop_preview()
+    picam2.stop()

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -62,6 +62,7 @@ tests/context_test.py
 tests/display_transform_null.py
 tests/display_transform_qt.py
 tests/easy_video2.py
+tests/egl_leak.py
 tests/encoder_start_stop.py
 tests/ffmpeg_abort.py
 tests/large_datagram.py


### PR DESCRIPTION
Some textures and context were not being cleaned up, apparently.

Also add a test for this.