### PR TITLE
Make LibavH264Encoder flush frames out at the right rate when necessary

### DIFF
--- a/picamera2/outputs/ffmpegoutput.py
+++ b/picamera2/outputs/ffmpegoutput.py
@@ -48,6 +48,8 @@ class FfmpegOutput(Output):
         self.timeout = 1 if audio else None
         # A user can set this to get notifications of FFmpeg failures.
         self.error_callback = None
+        # We don't understand timestamps, so an encoder may have to pace output to us.
+        self.needs_pacing = True
 
     def start(self):
         general_options = ['-loglevel', 'warning',

--- a/picamera2/outputs/output.py
+++ b/picamera2/outputs/output.py
@@ -12,6 +12,7 @@ class Output:
         """
         self.recording = False
         self.ptsoutput = pts
+        self.needs_pacing = False
 
     def start(self):
         """Start recording"""


### PR DESCRIPTION
This means they'll get passed to FfmpegOutput at the rate that generates the correct timestamps. We avoid pacing the output like this when the output classes don't require it.

Currently not doing this for LibavMjpegEncoder because MJPEG files don't have timestamps.