### PR TITLE
ffmpegoutput: improve clean up

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9.13'
+        python-version: '3.9.19'
     - name: Update
       run: sudo apt update
     - name: Install apt dependencies
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9.13'
+        python-version: '3.9.19'
     - name: Display python version
       run: python -c "import sys; print(sys.version)"
     - name: Update

--- a/picamera2/outputs/ffmpegoutput.py
+++ b/picamera2/outputs/ffmpegoutput.py
@@ -1,3 +1,4 @@
+import gc
 import signal
 import subprocess
 
@@ -93,6 +94,8 @@ class FfmpegOutput(Output):
                 except Exception:
                     pass
             self.ffmpeg = None
+            # This seems to be necessary to get the subprocess to clean up fully.
+            gc.collect()
 
     def outputframe(self, frame, keyframe=True, timestamp=None):
         if self.recording and self.ffmpeg:


### PR DESCRIPTION
A gc.collect() seems to be required to get the ffmpeg process to be fully cleaned up. (Specifically, ps -eLf was showing that the process's threads were still present.)