### PR TITLE
A couple of miscellaneous fixes

### DIFF
--- a/picamera2/encoders/encoder.py
+++ b/picamera2/encoders/encoder.py
@@ -38,6 +38,8 @@ class Encoder:
         self._name = None
         self._lock = threading.Lock()
         self.firsttimestamp = None
+        self.frame_skip_count = 1
+        self._skip_count = 0
 
     @property
     def running(self):
@@ -206,8 +208,10 @@ class Encoder:
         :param request: Request
         :type request: request
         """
-        with self._lock:
-            self._encode(stream, request)
+        if self._skip_count == 0:
+            with self._lock:
+                self._encode(stream, request)
+        self._skip_count = (self._skip_count + 1) % self.frame_skip_count
 
     def _encode(self, stream, request):
         if isinstance(stream, str):


### PR DESCRIPTION
The first fix is for DRM display devices that don't support alpha blending for overlays. This will make them work for displaying the camera images, just you can't have overlays.

The second is a small encoder features which allows you to skip frames, for example, "encoder only every other frame".