### PR TITLE
More robust platform checking

### DIFF
--- a/picamera2/platform.py
+++ b/picamera2/platform.py
@@ -12,17 +12,17 @@ class Platform(Enum):
 
 _platform = Platform.VC4
 try:
-    for num in range(5):
+    for num in range(64):
         device = '/dev/video' + str(num)
         if os.path.exists(device):
             with open(device, 'rb+', buffering=0) as fd:
                 caps = v4l2.v4l2_capability()
                 fcntl.ioctl(fd, v4l2.VIDIOC_QUERYCAP, caps)
                 decoded = caps.card.decode('utf-8')
-                if decoded == "rp1-cfe":
+                if decoded == "pispbe":
                     _platform = Platform.PISP
                     break
-                elif decoded == "unicam":
+                elif decoded == "bcm2835-isp":
                     break
 except Exception:
     pass


### PR DESCRIPTION
Increase the range of device nodes to search for a known device as they may be assigned automatically by the kernel probe order.

Additionally, switch from using the CFE driver to the Backend driver when identifying a platform as the latter now has a fixed UAPI, and will always be present even if a sensor probe fails.