### PR TITLE
DRM mirror across two displays

### DIFF
--- a/picamera2/previews/drm_preview.py
+++ b/picamera2/previews/drm_preview.py
@@ -25,21 +25,26 @@ class DrmManager():
             if self.use_count == 0:
                 self.card = pykms.Card()
                 self.resman = pykms.ResourceManager(self.card)
-                conn = self.resman.reserve_connector()
+                conn = self.resman.reserve_connector('HDMI-A-2')
                 self.crtc = self.resman.reserve_crtc(conn)
+                conn2 = self.resman.reserve_connector('HDMI-A-1')
+                self.crtc2 = self.resman.reserve_crtc(conn2)
             self.use_count += 1
         drm_preview.card = self.card
         drm_preview.resman = self.resman
         drm_preview.crtc = self.crtc
+        drm_preview.crtc2 = self.crtc2
 
     def remove(self, drm_preview):
         drm_preview.card = None
         drm_preview.resman = None
         drm_preview.crtc = None
+        drm_preview.crtc2 = None
         with self.lock:
             self.use_count -= 1
             if self.use_count == 0:
                 self.crtc = None
+                self.crtc2 = None
                 self.resman = None
                 self.card = None
                 gc.collect()
@@ -86,6 +91,7 @@ class DrmPreview(NullPreview):
         DrmPreview._manager.add(self)
 
         self.plane = None
+        self.plane2 = None
         self.drmfbs = {}
         self.current = None
         self.own_current = False
@@ -151,9 +157,11 @@ class DrmPreview(NullPreview):
             fmt = self.FMT_MAP[pixel_format]
 
             self.plane = self.resman.reserve_overlay_plane(self.crtc, format=fmt)
+            self.plane2 = self.resman.reserve_overlay_plane(self.crtc2, format=fmt)
             if self.plane is None:
                 # Some display devices may not support "alpha".
                 self.plane = self.resman.reserve_plane(self.crtc, type=pykms.PlaneType.Primary, format=fmt)
+                self.plane2 = self.resman.reserve_plane(self.crtc2, type=pykms.PlaneType.Primary, format=fmt)
                 if self.plane is None:
                     raise RuntimeError("Failed to reserve DRM plane")
             drm_rotation = 1
@@ -211,6 +219,7 @@ class DrmPreview(NullPreview):
 
             drmfb = self.drmfbs[fb]
             ctx.add_plane(self.plane, drmfb, self.crtc, (0, 0, width, height), (x, y, w, h))
+            ctx.add_plane(self.plane2, drmfb, self.crtc2, (0, 0, width, height), (x, y, w, h))
 
         overlay_new_fb = self.overlay_new_fb
         if overlay_new_fb != self.overlay_fb:
@@ -241,3 +250,4 @@ class DrmPreview(NullPreview):
         self.mem = None
         self.fb = None
         DrmPreview._manager.remove(self)
+


### PR DESCRIPTION
Simple example to make the two HDMI outputs on the pi 4 to mirror the DRM preview. (Didn't add overlay mirroring)
A general implementation would be to get an array of all available crtcs from all DRM cards and create all all necessary planes for use in the atomic commit.
Also different transforms for different monitors or a fullscreen option could be considered (I for example want fullscreen previews for all connected monitors regardless of their resolution).

https://github.com/raspberrypi/picamera2/issues/1073#issuecomment-2243081544