### PR TITLE
Replace apt with pip packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     python_requires='>=3.9',
     licence='BSD 2-Clause License',
     install_requires=['numpy', 'PiDNG', 'piexif', 'pillow', 'simplejpeg', 'v4l2-python3',
-                      'python-prctl', 'av', 'python3-libarchive-c', 'python3-tqdm',
-                      'python3-jsonschema'],
+                      'python-prctl', 'av', 'libarchive-c', 'tqdm',
+                      'jsonschema'],
     extras_require={"gui": ['pyopengl', 'PyQt5']})


### PR DESCRIPTION
The setup.py file currently contains packages with the prefix `python3-`, which are apt package names not pip package names, and therefore `pip install picamera2` doesn't work and throws the following errors
```
ERROR: Could not find a version that satisfies the requirement python3-jsonschema (from picamera2) (from versions: none)
ERROR: No matching distribution found for python3-jsonschema
```

Fix this by removing the `python3-` prefix from the relevant packages in setup.py