### PR TITLE
support imx500 to run more output tensors

### DIFF
--- a/picamera2/devices/imx500/imx500.py
+++ b/picamera2/devices/imx500/imx500.py
@@ -20,7 +20,7 @@ from v4l2 import (VIDIOC_S_CTRL, VIDIOC_S_EXT_CTRLS, v4l2_control,
 from picamera2 import CompletedRequest, Picamera2
 
 NETWORK_NAME_LEN = 64
-MAX_NUM_TENSORS = 8
+MAX_NUM_TENSORS = 16
 MAX_NUM_DIMENSIONS = 8
 
 FW_LOADER_STAGE = 0


### PR DESCRIPTION
Updated the magic number to 16, as MAX_NUM_TENSORS=8 is too limited for multi-task networks.