### PR TITLE
ci: Add Pyright static type checking workflow

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,0 +1,25 @@
+name: Pyright static type checking
+
+on:
+  pull_request:
+    branches: ['*']
+  workflow_dispatch:
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Node.js (needed for Pyright)
+        uses: actions/setup-node@v4
+        with:
+          node-version: current
+
+      - name: Install Pyright
+        run: npm install -g pyright
+
+      - name: Run Pyright static type checker
+        run: pyright

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,22 @@
+{
+  "include": ["picamera2"],
+  "exclude": ["tests"],
+  "reportMissingImports": false,
+  "reportMissingTypeStubs": false,
+  "reportUnknownMemberType": "warning",
+  "reportOptionalMemberAccess": "warning",
+  "reportGeneralTypeIssues": "warning",
+  "reportAttributeAccessIssue": "warning",
+  "reportUndefinedVariable": "warning",
+  "reportOptionalOperand": "warning",
+  "reportAssignmentType": "warning",
+  "reportInvalidTypeArguments": "warning",
+  "reportCallIssue": "warning",
+  "reportOptionalSubscript": "warning",
+  "reportArgumentType": "warning",
+  "reportOperatorIssue": "warning",
+  "reportReturnType": "warning",
+  "reportOptionalIterable": "warning",
+  "reportIndexIssue": "warning",
+  "typeCheckingMode": "basic"
+}


### PR DESCRIPTION
This pull request introduces Pyright, a static type-checking tool for Python, into the GitHub Actions CI pipeline. 

As part of addressing issue [#1192](https://github.com/RaspberryPi/picamera2/issues/1192), this addition encourages gradual improvements in type annotations while providing developers with immediate feedback on type-related issues.

At this stage, the pipeline warns about type issues and doesn’t enforce strict checking. This is intentional to allow gradual type annotation improvements over time.