### PR TITLE
Solve logical errors in `configure_` and some more refactors of `picamera2` module

### DIFF
--- a/picamera2/job.py
+++ b/picamera2/job.py
@@ -25,8 +25,7 @@ class Job(Generic[T]):
     """
 
     def __init__(self, functions: list[Callable[..., Union[
-            tuple[Literal[False], None],
-            tuple[Literal[True], Any],
+            tuple[bool, Any],
             tuple[Literal[True], T]]]], signal_function=None
     ):
         self._functions = functions


### PR DESCRIPTION
Follow-up of [#1234](https://github.com/raspberrypi/picamera2/pull/1234)

- 1st commit: minor refactors (partly based on [#1234(comment)](https://github.com/raspberrypi/picamera2/pull/1234#issuecomment-2769270009), [ #1177(comment)](https://github.com/raspberrypi/picamera2/pull/1177#issuecomment-2548547638), [#1248(comment)](https://github.com/raspberrypi/picamera2/pull/1248#issuecomment-2789050995))
- 2nd commit: 
1. Now a custom `dict` also gets patched, along with `CameraConfiguration`
2. [L1089](https://github.com/raspberrypi/picamera2/blob/f420184f54b8e5c726b65c450fbe3bbed215df42/picamera2/picamera2.py#L1089) is not required and was probably an oversight
3. the `else` block would update the `video_configuration` property even when a custom `dict` or `CameraConfiguration` object was passed.