### PR TITLE
use yuvj420 (pyav jpeg full range)

### DIFF
--- a/picamera2/encoders/libav_mjpeg_encoder.py
+++ b/picamera2/encoders/libav_mjpeg_encoder.py
@@ -47,7 +47,7 @@ class LibavMjpegEncoder(Encoder):
 
         self._stream.width = self.width
         self._stream.height = self.height
-        self._stream.pix_fmt = "yuv420p"
+        self._stream.pix_fmt = "yuvj420p"
 
         for out in self._output:
             out._add_stream(self._stream, self._codec, rate=self.framerate)
@@ -64,7 +64,7 @@ class LibavMjpegEncoder(Encoder):
 
         self._stream.codec_context.qmin = self.qp
         self._stream.codec_context.qmax = self.qp
-        self._stream.codec_context.color_range = 2  # JPEG (full range)
+        
         try:
             # "qscale" is now correct, but some older versions used "QSCALE"
             self._stream.codec_context.flags |= av.codec.context.Flags.qscale  # noqa
@@ -73,7 +73,7 @@ class LibavMjpegEncoder(Encoder):
 
         self._stream.codec_context.time_base = Fraction(1, 1000000)
 
-        FORMAT_TABLE = {"YUV420": "yuv420p",
+        FORMAT_TABLE = {"YUV420": "yuvj420p",
                         "BGR888": "rgb24",
                         "RGB888": "bgr24",
                         "XBGR8888": "rgba",

--- a/picamera2/outputs/pyavoutput.py
+++ b/picamera2/outputs/pyavoutput.py
@@ -30,12 +30,15 @@ class PyavOutput(Output):
     def _add_stream(self, encoder_stream, codec_name, **kwargs):
         # The output container that does the muxing needs to know about the streams for which packets
         # will be sent to it. It literally needs to copy them for the output container.
+        print(encoder_stream)
+        print()
         stream = self._container.add_stream(codec_name, **kwargs)
-
-        if codec_name == "mjpeg":
-            # Well, this is nasty. MJPEG seems to need this.
-            stream.codec_context.color_range = 2  # JPEG (full range)
-
+        print(stream)
+        stream.codec_context.width = encoder_stream.codec_context.width
+        stream.codec_context.height = encoder_stream.codec_context.height
+        stream.codec_context.pix_fmt = encoder_stream.codec_context.pix_fmt
+        print(stream)
+        
         self._streams[encoder_stream] = stream
 
     def start(self):


### PR DESCRIPTION
YUVJ420 is full range jpeg in terms of PyAV. 

Executing the example `capture_pyav.py` gives following output with this change:
```
<av.VideoStream #0 mjpeg, yuvj420p 1280x720 at 0x7fff7d4a58f0>

<av.VideoStream #0 mjpeg, yuv420p 640x480 at 0x7fff7d4a5b20>
<av.VideoStream #0 mjpeg, yuvj420p 1280x720 at 0x7fff7d4a5b20>
```
It means, the codec_context is not copied from the encoder, but at least the width/height/pix_fmt seem to be relevant for the output stream to write correct output.

The output file is created with this change as before but not using the range setting but the pix_fmt.

