### PR TITLE
Handle ExposureTimeMode and AnalogueGainMode controls transparently

### DIFF
--- a/tests/aegc.py
+++ b/tests/aegc.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+
+import time
+
+from picamera2 import Picamera2
+
+
+def test_control_fixed(control, value):
+    picam2.set_controls({control: value})
+    time.sleep(1.0)
+    check = picam2.capture_metadata()[control]
+    if abs(check - value) > value * 0.05:
+        print(f"ERROR: requested {control} of {value} but got {check}")
+    else:
+        print(f"Requested {control} of {value}, got {check}")
+
+
+def test_control_auto(control):
+    current = picam2.capture_metadata()[control]
+    picam2.set_controls({control: 0})
+    time.sleep(1.0)
+    for _ in range(5):
+        check = picam2.capture_metadata()[control]
+        if abs(check - current) > current * 0.05:
+            print(f"Control {control} changed from {current} to {check}")
+            return
+    print(f"ERROR: {control} has not returned to auto - still {check}")
+
+
+picam2 = Picamera2()
+picam2.start()
+
+test_control_fixed("ExposureTime", 5000)
+test_control_fixed("ExposureTime", 10000)
+test_control_auto("ExposureTime")
+
+test_control_fixed("AnalogueGain", 1.5)
+test_control_fixed("AnalogueGain", 3.0)
+test_control_auto("AnalogueGain")

--- a/tests/test_list.txt
+++ b/tests/test_list.txt
@@ -51,6 +51,7 @@ examples/tuning_file.py
 examples/video_with_config.py
 examples/window_offset.py
 examples/zoom.py
+tests/aegc.py
 tests/alignment.py
 tests/app_dual.py
 tests/app_full_test.py


### PR DESCRIPTION
libcamera now has ExposureTimeMode and AnalogueGainMode mode controls, which must be set to "manual" before you can set fixed exposure or gain values. Likewise, the modes must be "cleared" to return to auto mode (setting zero no longer does anything).

We're going to handle all this transparently for users, because in nearly all cases it adds nothing useful and would be an unwelcome API change.