### PR TITLE
Fix setting of recording to False in stop() call of CircularOutput2

### DIFF
--- a/picamera2/outputs/circularoutput2.py
+++ b/picamera2/outputs/circularoutput2.py
@@ -114,7 +114,7 @@ class CircularOutput2(Output):
         with self._lock:
             if not self.recording:
                 raise RuntimeError("Circular output was not started")
-            self._recording = False
+            self.recording = False
             self._output = None
 
         # At this point the background thread can't be using the circular buffer or the output,


### PR DESCRIPTION
Right now stoping CircularOutput2 does not correctly set recording to False.

All other instances use `self.recording` while here `self._recording` was used.