### PR TITLE
Handle ExposureTimeMode and AnalogueGainMode at camera start

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1175,6 +1175,18 @@ class Picamera2:
         if self.started:
             return
         controls = self.controls.get_libcamera_controls()
+
+        # The latest libcamera requires is to set "ExposureTimeMode" to manual if we are setting
+        # a fixed value, or to "auto" if we're going back to auto mode.
+        exposure_time = controls.get(libcamera.controls.ExposureTime, None)
+        if exposure_time is not None:
+            controls[libcamera.controls.ExposureTimeMode] = 0 if exposure_time == 0 else 1
+
+        # Ditto for the analogue gain.
+        analogue_gain = controls.get(libcamera.controls.AnalogueGain, None)
+        if analogue_gain is not None:
+            controls[libcamera.controls.AnalogueGainMode] = 0 if analogue_gain == 0 else 1
+
         self.controls = Controls(self)
         # camera.start() now throws an error if it fails.
         self.camera.start(controls)

--- a/tests/aegc.py
+++ b/tests/aegc.py
@@ -37,3 +37,28 @@ test_control_auto("ExposureTime")
 test_control_fixed("AnalogueGain", 1.5)
 test_control_fixed("AnalogueGain", 3.0)
 test_control_auto("AnalogueGain")
+
+
+# Also test that it works when we start the camera.
+
+def test_control_start(control, value):
+    controls = {control: value}
+    config = picam2.create_preview_configuration(controls=controls)
+    picam2.start(config)
+
+    # The very first frame should have the given values.
+    metadata = picam2.capture_metadata()
+    picam2.stop()
+    check = metadata[control]
+    print(f"Camera started with {control} {check}")
+
+    if abs(value - check) > 0.05 * value:
+        print(f"ERROR: request {control} of {value} but got {check}")
+
+
+picam2.stop()
+
+test_control_start("ExposureTime", 12345)
+test_control_start("ExposureTime", 23456)
+test_control_start("AnalogueGain", 1.5)
+test_control_start("AnalogueGain", 3.0)


### PR DESCRIPTION
The previous commit only handled it when a request was being sent, not when the camera is being started.