### PR TITLE
Save the sensor name as the "Model" in DNG files

### DIFF
--- a/picamera2/request.py
+++ b/picamera2/request.py
@@ -442,7 +442,8 @@ class Helpers:
             config['stride'] = raw.shape[1]
             config['framesize'] = raw.shape[0] * raw.shape[1]
 
-        camera = Picamera2Camera(config, metadata)
+        model = self.picam2.camera_properties.get('Model') or "Picamera2"
+        camera = Picamera2Camera(config, metadata, model)
         r = PICAM2DNG(camera)
 
         dng_compress_level = self.picam2.options.get("compress_level", 0)


### PR DESCRIPTION
Otherwise there's no way to identify the sensor and camera tuning file from the DNG file. This behaviour matches rpicam-still.

Requires the udpated PiDNG.