### PR TITLE
Discard requests that did not complete successfully

### DIFF
--- a/picamera2/picamera2.py
+++ b/picamera2/picamera2.py
@@ -1335,6 +1335,9 @@ class Picamera2:
         with self._requestslock:
             requests = self._requests
             self._requests = []
+        # Discard "startup frames", or frames with errors etc.
+        requests = [req for req in requests
+                    if next(iter(req.request.buffers.values())).metadata.status == libcamera.FrameMetadata.Status.Success]
         self.frames += len(requests)
         # It works like this:
         # * We maintain a list of the requests that libcamera has completed (completed_requests).


### PR DESCRIPTION
This may include ones that report an error (not that the Pi does), but in particular when the libcamera change is committed that introduces "startup frames". This check will detect and discard them correctly with no further modification.