### PR TITLE
picamera2: Switch from using v4l2-python3 to videodev2

### DIFF
--- a/picamera2/devices/imx500/imx500.py
+++ b/picamera2/devices/imx500/imx500.py
@@ -14,8 +14,8 @@ import numpy as np
 from libarchive.read import fd_reader
 from libcamera import Rectangle, Size
 from tqdm import tqdm
-from v4l2 import (VIDIOC_G_EXT_CTRLS, VIDIOC_S_CTRL, VIDIOC_S_EXT_CTRLS,
-                  v4l2_control, v4l2_ext_control, v4l2_ext_controls)
+from videodev2 import (VIDIOC_G_EXT_CTRLS, VIDIOC_S_CTRL, VIDIOC_S_EXT_CTRLS,
+                       v4l2_control, v4l2_ext_control, v4l2_ext_controls)
 
 from picamera2 import CompletedRequest, Picamera2
 

--- a/picamera2/devices/imx708/imx708.py
+++ b/picamera2/devices/imx708/imx708.py
@@ -1,7 +1,7 @@
 import fcntl
 import os
 
-from v4l2 import VIDIOC_S_CTRL, v4l2_control
+from videodev2 import VIDIOC_S_CTRL, v4l2_control
 
 from picamera2 import Picamera2
 

--- a/picamera2/dma_heap.py
+++ b/picamera2/dma_heap.py
@@ -3,7 +3,7 @@ import fcntl
 import logging
 import os
 
-from v4l2 import _IOW, _IOWR
+from videodev2 import _IOW, _IOWR
 
 _log = logging.getLogger("picamera2")
 heapNames = [

--- a/picamera2/encoders/__init__.py
+++ b/picamera2/encoders/__init__.py
@@ -1,6 +1,6 @@
 import fcntl
 
-import v4l2
+import videodev2
 
 from .encoder import Encoder, Quality
 from .jpeg_encoder import JpegEncoder
@@ -11,8 +11,8 @@ from .multi_encoder import MultiEncoder
 _hw_encoder_available = False
 try:
     with open('/dev/video11', 'rb', buffering=0) as fd:
-        caps = v4l2.v4l2_capability()
-        fcntl.ioctl(fd, v4l2.VIDIOC_QUERYCAP, caps)
+        caps = videodev2.v4l2_capability()
+        fcntl.ioctl(fd, videodev2.VIDIOC_QUERYCAP, caps)
         _hw_encoder_available = (caps.card.decode('utf-8') == "bcm2835-codec-encode")
 except Exception:
     pass

--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -1,17 +1,17 @@
 """H264 encoder functionality"""
 
-from v4l2 import (V4L2_CID_MPEG_VIDEO_H264_I_PERIOD,
-                  V4L2_CID_MPEG_VIDEO_H264_LEVEL,
-                  V4L2_CID_MPEG_VIDEO_H264_MAX_QP,
-                  V4L2_CID_MPEG_VIDEO_H264_MIN_QP,
-                  V4L2_CID_MPEG_VIDEO_H264_PROFILE,
-                  V4L2_CID_MPEG_VIDEO_REPEAT_SEQ_HEADER,
-                  V4L2_MPEG_VIDEO_H264_LEVEL_4_1,
-                  V4L2_MPEG_VIDEO_H264_LEVEL_4_2,
-                  V4L2_MPEG_VIDEO_H264_PROFILE_BASELINE,
-                  V4L2_MPEG_VIDEO_H264_PROFILE_CONSTRAINED_BASELINE,
-                  V4L2_MPEG_VIDEO_H264_PROFILE_HIGH,
-                  V4L2_MPEG_VIDEO_H264_PROFILE_MAIN, V4L2_PIX_FMT_H264)
+from videodev2 import (V4L2_CID_MPEG_VIDEO_H264_I_PERIOD,
+                       V4L2_CID_MPEG_VIDEO_H264_LEVEL,
+                       V4L2_CID_MPEG_VIDEO_H264_MAX_QP,
+                       V4L2_CID_MPEG_VIDEO_H264_MIN_QP,
+                       V4L2_CID_MPEG_VIDEO_H264_PROFILE,
+                       V4L2_CID_MPEG_VIDEO_REPEAT_SEQ_HEADER,
+                       V4L2_MPEG_VIDEO_H264_LEVEL_4_1,
+                       V4L2_MPEG_VIDEO_H264_LEVEL_4_2,
+                       V4L2_MPEG_VIDEO_H264_PROFILE_BASELINE,
+                       V4L2_MPEG_VIDEO_H264_PROFILE_CONSTRAINED_BASELINE,
+                       V4L2_MPEG_VIDEO_H264_PROFILE_HIGH,
+                       V4L2_MPEG_VIDEO_H264_PROFILE_MAIN, V4L2_PIX_FMT_H264)
 
 from picamera2.encoders import Quality
 from picamera2.encoders.v4l2_encoder import V4L2Encoder

--- a/picamera2/encoders/mjpeg_encoder.py
+++ b/picamera2/encoders/mjpeg_encoder.py
@@ -1,6 +1,6 @@
 """MJPEG encoder functionality utilising V4L2"""
 
-from v4l2 import V4L2_PIX_FMT_MJPEG
+from videodev2 import V4L2_PIX_FMT_MJPEG
 
 from picamera2.encoders import Quality, _hw_encoder_available
 from picamera2.encoders.v4l2_encoder import V4L2Encoder

--- a/picamera2/encoders/v4l2_encoder.py
+++ b/picamera2/encoders/v4l2_encoder.py
@@ -7,7 +7,7 @@ import queue
 import select
 import threading
 
-from v4l2 import *
+from vidoedev2 import *
 
 from picamera2.encoders.encoder import Encoder
 

--- a/picamera2/platform.py
+++ b/picamera2/platform.py
@@ -2,7 +2,7 @@ import fcntl
 import os
 from enum import Enum
 
-import v4l2
+import videodev2
 
 
 class Platform(Enum):
@@ -16,9 +16,9 @@ try:
         device = '/dev/video' + str(num)
         if os.path.exists(device):
             with open(device, 'rb+', buffering=0) as fd:
-                caps = v4l2.v4l2_capability()
-                fcntl.ioctl(fd, v4l2.VIDIOC_QUERYCAP, caps)
-                decoded = caps.card.decode('utf-8')
+                caps = videodev2.v4l2_capability()
+                fcntl.ioctl(fd, videodev2.VIDIOC_QUERYCAP, caps)
+                decoded = videodev2.arr_to_str(caps.card)
                 if decoded == "pispbe":
                     _platform = Platform.PISP
                     break

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
               'picamera2.allocators'],
     python_requires='>=3.9',
     licence='BSD 2-Clause License',
-    install_requires=['numpy', 'PiDNG', 'piexif', 'pillow', 'simplejpeg', 'v4l2-python3',
+    install_requires=['numpy', 'PiDNG', 'piexif', 'pillow', 'simplejpeg', 'videodev2',
                       'python-prctl', 'av', 'libarchive-c', 'tqdm',
                       'jsonschema'],
     extras_require={"gui": ['pyopengl', 'PyQt5']})


### PR DESCRIPTION
Use the Raspberry Pi implementation of the V4L2 UAPI python wrapper throughout the codebase.

For all but one part, this is a simple s/v4l2/videodev2/ substitution. For the platfom.py case, a helper function is needed to convert from ctypes u8 array to a string.