### PR TITLE
picamera2 init: Don't override LIBCAMERA_RPI_CONFIG_FILE if valid

### DIFF
--- a/picamera2/__init__.py
+++ b/picamera2/__init__.py
@@ -19,6 +19,10 @@ if os.environ.get("XDG_SESSION_TYPE", None) == "wayland":
 
 
 def _set_configuration_file(filename):
+    oldval = os.environ.get('LIBCAMERA_RPI_CONFIG_FILE')
+    if oldval is not None and os.path.isfile(oldval):
+        return
+
     platform_dir = "vc4" if get_platform() == Platform.VC4 else "pisp"
     dirs = [
         os.path.expanduser(


### PR DESCRIPTION
If the environment variable already exists and points to a valid file, keep it. This allows the config file to be user-specified from outside the Python script.

To fix #1288