### PR TITLE
tests: Update the aegc test to reduce the chance of false positives

### DIFF
--- a/examples/imx500/imx500_get_device_id.py
+++ b/examples/imx500/imx500_get_device_id.py
@@ -11,6 +11,9 @@ picam2 = Picamera2()
 config = picam2.create_preview_configuration()
 picam2.start(config, show_preview=False)
 
+# wait for the device to be streaming
+picam2.capture_metadata()
+
 # get device_id
 device_id = imx500.get_device_id()
 print("IMX500 Device ID =", device_id)

--- a/tests/aegc.py
+++ b/tests/aegc.py
@@ -32,10 +32,12 @@ picam2.start()
 
 test_control_fixed("ExposureTime", 5000)
 test_control_fixed("ExposureTime", 10000)
+test_control_fixed("ExposureTime", 1000)
 test_control_auto("ExposureTime")
 
 test_control_fixed("AnalogueGain", 1.5)
 test_control_fixed("AnalogueGain", 3.0)
+test_control_fixed("AnalogueGain", 5.8)
 test_control_auto("AnalogueGain")
 
 


### PR DESCRIPTION
It's possible that the manual -> auto test will keep the exposure or gain at the same auto value as the last set manual value depending on scene conditions. This will cause a false positive failure result.

Reduce the possibility of this occurring by setting the last manual exposure and gain values to something non-typical.