### PR TITLE
Fix video resolution in mp4 file avc1 box

### DIFF
--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -86,7 +86,7 @@ class H264Encoder(V4L2Encoder):
 
         # The output objects may need to know what kind of stream this is.
         for out in self._output:
-            out._add_stream("video", "h264")
+            out._add_stream("video", "h264", width=self._width, height=self._height)
 
         super()._start()
 

--- a/picamera2/encoders/libav_h264_encoder.py
+++ b/picamera2/encoders/libav_h264_encoder.py
@@ -78,7 +78,7 @@ class LibavH264Encoder(Encoder):
         self._stream.pix_fmt = "yuv420p"
 
         for out in self._output:
-            out._add_stream(self._stream, self._codec, rate=self.framerate)
+            out._add_stream(self._stream, self._codec, rate=self.framerate, width=self.width, height=self.height)
 
         preset = "ultrafast"
         if self.profile is not None:

--- a/picamera2/encoders/mjpeg_encoder.py
+++ b/picamera2/encoders/mjpeg_encoder.py
@@ -38,6 +38,7 @@ class MJPEGEncoder(V4L2Encoder):
     def _start(self):
         # The output objects may need to know what kind of stream this is.
         for out in self._output:
-            out._add_stream("video", "mjpeg", rate=30)  # seem to need a rate to prevent timestamp warnings
+            # Seem to need a rate to prevent timestamp warnings.
+            out._add_stream("video", "mjpeg", rate=30, width=self.width, height=self.height)
 
         super()._start()


### PR DESCRIPTION
The PyAv output container is a kind of copy of the dummy one we use to fish out the encoder data. But we must set the correct output resolution too.