### PR TITLE
Fix incorrect Hailo reference counting and virtual device reuse

### DIFF
--- a/picamera2/devices/hailo/hailo.py
+++ b/picamera2/devices/hailo/hailo.py
@@ -25,7 +25,8 @@ class Hailo:
         self.hef = HEF(hef_path)
         if Hailo.TARGET is None:
             Hailo.TARGET = VDevice(params)
-            Hailo.TARGET_REF_COUNT += 1
+        # increment `TARGET_REF_COUNT` every time a model is loaded
+        Hailo.TARGET_REF_COUNT += 1
         self.target = Hailo.TARGET
         self.infer_model = self.target.create_infer_model(hef_path)
         self.infer_model.set_batch_size(1 if batch_size is None else batch_size)
@@ -184,3 +185,6 @@ class Hailo:
         Hailo.TARGET_REF_COUNT -= 1
         if Hailo.TARGET_REF_COUNT == 0:
             self.target.release()
+            # Reset `TARGET` to None so that subsequent __init__ calls can create
+            # a new VDevice, since this one has been released
+            Hailo.TARGET = None


### PR DESCRIPTION
## Fix incorrect Hailo reference counting and virtual device reuse

This PR fixes incorrect reference tracking of the shared virtual device in the `Hailo` class when used with multiple model instances.

### Problem

- `TARGET_REF_COUNT` was only incremented during the **first** virtual device allocation.  
  As a result, loading multiple models caused the `VDevice` to be **deallocated prematurely**, since each model called `.close()` and decremented the counter.

- `TARGET` was **not reset to `None`** after releasing the virtual device, which caused a released `VDevice` to be reused on the next model creation, resulting in runtime exceptions.

### Solution

- Moved the `TARGET_REF_COUNT += 1` line **outside** the `if TARGET is None` block to ensure it increments for *every* model.
- Reset `TARGET = None` after releasing the virtual device when the count reaches zero, allowing future instances to allocate a new one properly.

### Test programs

#### Test program illustrating premature deallocation

```python
from hailo import Hailo

m1 = Hailo("yolov8l.hef")
m2 = Hailo("yolov8l.hef")

with (m1, m2):
    pass  # before fix: Segfault
```

#### Test program illustrating reuse of released device

```python
from hailo import Hailo

with Hailo("yolov8l.hef") as m1:
    pass

with Hailo("yolov8l.hef") as m1:
    pass  # before fix: AttributeError: 'NoneType' object has no attribute 'create_infer_model_from_file'
```

### Summary of changes

- Adjusted reference count logic in `__init__` and `close`
- Added inline comments for clarity
- No change in external behavior

### Notes

This PR addresses the problems discussed in [Issue #1300](https://github.com/raspberrypi/picamera2/issues/1300).
