### PR TITLE
Add force_key_frame() for video encoders

### DIFF
--- a/picamera2/encoders/h264_encoder.py
+++ b/picamera2/encoders/h264_encoder.py
@@ -106,3 +106,7 @@ class H264Encoder(V4L2Encoder):
             actual_complexity = self.width * self.height * getattr(self, "framerate", 30)
             reference_bitrate = BITRATE_TABLE[quality] * 1000000
             self.bitrate = int(reference_bitrate * actual_complexity / reference_complexity)
+
+    def force_key_frame(self):
+        """Force a key frame to be encoded in the video stream as soon as possible."""
+        self._key_frames_requested += 1


### PR DESCRIPTION
An I-frame will be encoded into the output stream as soon as possible when

encoder.force_key_frame()

is called. Implemented for both libav and V4L2 H.264 encoders.