### PR TITLE
Add py.typed file to package source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=['picamera2', 'picamera2.devices', 'picamera2.devices.hailo', 'picamera2.devices.imx500',
               'picamera2.devices.imx708', 'picamera2.encoders', 'picamera2.outputs', 'picamera2.previews',
               'picamera2.allocators'],
-    package_data = {
+    package_data={
         'picamera2': ['py.typed'],
     },
     python_requires='>=3.9',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
     packages=['picamera2', 'picamera2.devices', 'picamera2.devices.hailo', 'picamera2.devices.imx500',
               'picamera2.devices.imx708', 'picamera2.encoders', 'picamera2.outputs', 'picamera2.previews',
               'picamera2.allocators'],
+    package_data = {
+        'picamera2': ['py.typed'],
+    },
     python_requires='>=3.9',
     licence='BSD 2-Clause License',
     install_requires=['numpy', 'PiDNG', 'piexif', 'pillow', 'simplejpeg', 'videodev2',


### PR DESCRIPTION
[PEP561](https://peps.python.org/pep-0561) says that packages that contain type 
hints should include a marker file `py.typed` in the top level of the package source to 
indicate that the package has type information. Some type checkers will not check 
libraries that are lacking this file. 

This PR adds this missing file, and adds configuration to `setup.py` to ensure it 
is included when building the package.