### PR TITLE
Fix use of MappedArray with LibcameraAllocator

### DIFF
--- a/picamera2/allocators/allocator.py
+++ b/picamera2/allocators/allocator.py
@@ -1,6 +1,9 @@
 class Allocator:
     """Base class for allocators"""
 
+    # Most allocators shouldn't need to "sync" buffers every time you access them.
+    needs_sync = False
+
     def __init__(self):
         self.sync = Sync
 

--- a/picamera2/allocators/libcameraallocator.py
+++ b/picamera2/allocators/libcameraallocator.py
@@ -10,6 +10,9 @@ _log = logging.getLogger("picamera2")
 class LibcameraAllocator(Allocator):
     """Uses the libcamera FrameBufferAllocator"""
 
+    # This legacy allocator does require a sync, but of course you shouldn't be using it.
+    needs_sync = True
+
     def __init__(self, camera):
         super().__init__()
         self.camera = camera

--- a/tests/allocator_test.py
+++ b/tests/allocator_test.py
@@ -4,7 +4,7 @@
 
 import time
 
-from picamera2 import Picamera2, Preview
+from picamera2 import MappedArray, Picamera2, Preview
 from picamera2.allocators import LibcameraAllocator
 
 picam2 = Picamera2()
@@ -16,6 +16,11 @@ picam2.configure(preview_config)
 
 picam2.start()
 time.sleep(2)
+
+# Check that MappedArray still works!
+with picam2.captured_request() as request:
+    with MappedArray(request, 'main') as m:
+        pass
 
 size = picam2.sensor_resolution
 # GPU won't digest images wider than 4096 on a Pi 4.


### PR DESCRIPTION
This was broken by commit c0cc32c ("Always sync buffers as writeable ...").

But of course LibcameraAllocator is only a legacy thing now, so you really shouldn't be using it.

Although the code here is now behaving as it did previously, it is rather unoptimised in that every MappedArray will do another mmap which could probably be avoided. But you won't get the LibcameraAllocator by default, and as stated, there is no reason to request one - so it doesn't seem worth the trouble of doing anything about it.