### PR TITLE
Import the av module only when required

### DIFF
--- a/picamera2/encoders/encoder.py
+++ b/picamera2/encoders/encoder.py
@@ -4,7 +4,6 @@ import threading
 from enum import Enum
 from fractions import Fraction
 
-import av
 from libcamera import controls
 
 import picamera2.formats as formats
@@ -316,6 +315,9 @@ class Encoder:
 
             # Start the audio, if that's been requested.
             if self.audio:
+                # Save low-powered Pis from importing av unless it is needed.
+                global av
+                import av
                 self._audio_input_container = av.open(**self.audio_input)
                 self._audio_input_stream = self._audio_input_container.streams.get(audio=0)[0]
                 self._audio_output_container = av.open("/dev/null", 'w', format="null")

--- a/picamera2/encoders/libav_h264_encoder.py
+++ b/picamera2/encoders/libav_h264_encoder.py
@@ -5,8 +5,6 @@ import time
 from fractions import Fraction
 from math import sqrt
 
-import av
-
 import picamera2.platform as Platform
 from picamera2.encoders.encoder import Encoder, Quality
 
@@ -18,6 +16,9 @@ class LibavH264Encoder(Encoder):
 
     def __init__(self, bitrate=None, repeat=True, iperiod=30, framerate=30, qp=None, profile=None):
         """Initialise"""
+        # Save low-powered Pis from importing av unless it is needed.
+        global av
+        import av
         super().__init__()
         self._codec = "h264"  # for now only support h264
         self.repeat = repeat

--- a/picamera2/encoders/libav_mjpeg_encoder.py
+++ b/picamera2/encoders/libav_mjpeg_encoder.py
@@ -3,8 +3,6 @@
 import collections
 from fractions import Fraction
 
-import av
-
 from picamera2.encoders.encoder import Encoder, Quality
 
 from ..request import MappedArray
@@ -15,6 +13,9 @@ class LibavMjpegEncoder(Encoder):
 
     def __init__(self, bitrate=None, repeat=True, iperiod=30, framerate=30, qp=None):
         """Initialise"""
+        # Save low-powered Pis from importing av unless it is needed.
+        global av
+        import av
         super().__init__()
         self._codec = "mjpeg"
         self.repeat = repeat

--- a/picamera2/outputs/pyavoutput.py
+++ b/picamera2/outputs/pyavoutput.py
@@ -1,7 +1,5 @@
 from fractions import Fraction
 
-import av
-
 from .output import Output
 
 
@@ -19,6 +17,9 @@ class PyavOutput(Output):
     """
 
     def __init__(self, output_name, format=None, pts=None, options=None):
+        # Save low-powered Pis from importing av unless it is needed.
+        global av
+        import av
         super().__init__(pts=pts)
         self._output_name = output_name
         self._format = format


### PR DESCRIPTION
The classes that use av can import it only once we know it is required.