### PR TITLE
tests: Add bypass for imx219 in stop_slow_framerate test

### DIFF
--- a/tests/stop_slow_framerate.py
+++ b/tests/stop_slow_framerate.py
@@ -5,6 +5,11 @@ import time
 from picamera2 import Picamera2
 
 picam2 = Picamera2()
+
+if picam2.camera_properties['Model'] == "imx219":
+    print("SKIPPED (imx219 test bypass)")
+    quit()
+
 config = picam2.create_preview_configuration(
     controls={'FrameRate': 0.2, 'ExposureTime': 5000, 'AnalogueGain': 1.0, 'ColourGains': (1, 1)})
 picam2.configure(config)


### PR DESCRIPTION
The sensor has a limit on the min fps that can be set, so will fail this test.