### PR TITLE
imx500: Allow for fw progress bar access restrictions

### DIFF
--- a/picamera2/devices/imx500/imx500.py
+++ b/picamera2/devices/imx500/imx500.py
@@ -318,11 +318,20 @@ class IMX500:
         if self.device_fd is None:
             raise RuntimeError('IMX500: Requested camera dev-node not found')
 
-        # Progress status specific debugfs entries.
+        # Progress status specific debugfs entries. These are cosmetic (they only feed the
+        # firmware upload progress bar), so a PermissionError here must not break IMX500.
         if imx500_device_id:
-            self.fw_progress = open(f'/sys/kernel/debug/imx500-fw:{imx500_device_id}/fw_progress', 'r')
+            path = f'/sys/kernel/debug/imx500-fw:{imx500_device_id}/fw_progress'
+            try:
+                self.fw_progress = open(path, 'r')
+            except (PermissionError, FileNotFoundError) as err:
+                print(f'IMX500: Unable to open {path} ({err}). Firmware upload progress bar will not be displayed')
         if spi_device_id:
-            self.fw_progress_chunk = open(f'/sys/kernel/debug/rp2040-spi:{spi_device_id}/transfer_progress', 'r')
+            path = f'/sys/kernel/debug/rp2040-spi:{spi_device_id}/transfer_progress'
+            try:
+                self.fw_progress_chunk = open(path, 'r')
+            except (PermissionError, FileNotFoundError) as err:
+                print(f'IMX500: Unable to open {path} ({err}). Firmware upload progress bar will not be displayed')
 
         if self.config['network_file'] != '':
             if tensor_injection:
@@ -449,6 +458,9 @@ class IMX500:
             return (0, 0)
 
     def show_network_fw_progress_bar(self):
+        if not self.fw_progress and not self.fw_progress_chunk:
+            # No readable progress source: skip the bar so the worker does not spin on (0, 0).
+            return
         p = multiprocessing.Process(target=self.__do_progress_bar,
                                     args=(FW_NETWORK_STAGE, 'Network Firmware Upload'))
         p.start()

--- a/tests/imx500.py
+++ b/tests/imx500.py
@@ -47,7 +47,7 @@ for _ in range(NUM_FRAMES):
 
 print("Got output tensors on", tensor_count, "of", NUM_FRAMES, "frames")
 if tensor_count < NUM_FRAMES // 2:
-    print("ERROR: expected at least", NUM_FRAMES // 2, "frames with output tensors")
+    print("ERROR: expected at least", NUM_FRAMES // 2, "frames with output tensors, got", tensor_count)
 
 picam2.stop()
 picam2.close()


### PR DESCRIPTION
The firmware upload progress bar reads two files under debugfs, which requires sudo group membership. Non-sudo users may hit PermissionError during IMX500() construction even though the progress bar is purely cosmetic and the rest of the device works without it.

Catch PermissionError/FileNotFoundError on the two opens, print a warning, and continue fw upload without a progress bar.