### PR TITLE
imx500: Allow firmware progress bar to work for non-sudo users

### DIFF
--- a/picamera2/devices/imx500/debug_stream_imx500.sh
+++ b/picamera2/devices/imx500/debug_stream_imx500.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# For instructions on how to used this script, please refer to the
+# Picamera2 file imx500_progress_bar.txt.
+
+SOURCE="/sys/kernel/debug/imx500-fw:$1/fw_progress"
+
+if [ ! -f "$SOURCE" ]; then
+    echo "Error: $SOURCE not found" >&2
+    exit 1
+fi
+
+exec cat "$SOURCE"

--- a/picamera2/devices/imx500/debug_stream_rp2040.sh
+++ b/picamera2/devices/imx500/debug_stream_rp2040.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# For instructions on how to used this script, please refer to the
+# Picamera2 file imx500_progress_bar.txt.
+
+SOURCE="/sys/kernel/debug/rp2040-spi:$1/transfer_progress"
+
+if [ ! -f "$SOURCE" ]; then
+    echo "Error: $SOURCE not found" >&2
+    exit 1
+fi
+
+exec cat "$SOURCE"

--- a/picamera2/devices/imx500/imx500.py
+++ b/picamera2/devices/imx500/imx500.py
@@ -5,7 +5,9 @@ import json
 import multiprocessing
 import os
 import struct
+import subprocess
 import time
+from enum import IntEnum
 from typing import List, Optional
 
 import Imath
@@ -298,10 +300,13 @@ class NetworkIntrinsics:
 
 
 class IMX500:
+    class FwProgressType(IntEnum):
+        NONE = (0,)  # fw update progress bar not available
+        DIRECT = (1,)  # can read files in /sys/kernel/debug directly
+        INDIRECT = 2  # need to use debug_stream* scripts with passwordless sudo
+
     def __init__(self, network_file: str, camera_id: str = '', tensor_injection: bool = False):
         self.device_fd = None
-        self.fw_progress = None
-        self.fw_progress_chunk = None
         self.__cfg = {'network_file': network_file, 'input_tensor': {}}
 
         imx500_device_id = None
@@ -329,20 +334,23 @@ class IMX500:
         if self.device_fd is None:
             raise RuntimeError('IMX500: Requested camera dev-node not found')
 
-        # Progress status specific debugfs entries. These are cosmetic (they only feed the
-        # firmware upload progress bar), so a PermissionError here must not break IMX500.
-        if imx500_device_id:
-            path = f'/sys/kernel/debug/imx500-fw:{imx500_device_id}/fw_progress'
+        self.imx500_device_id = imx500_device_id
+        self.spi_device_id = spi_device_id
+
+        # Find out how, if at all, we can access the debugfs files that tell us the
+        # firmware upload progress.
+        try:
+            self.fw_progress = IMX500.FwProgressType.DIRECT
+            self._fw_progress_read()
+            self._fw_progress_chunk_read()
+        except subprocess.CalledProcessError:
             try:
-                self.fw_progress = open(path, 'r')
-            except (PermissionError, FileNotFoundError) as err:
-                print(f'IMX500: Unable to open {path} ({err}). Firmware upload progress bar will not be displayed')
-        if spi_device_id:
-            path = f'/sys/kernel/debug/rp2040-spi:{spi_device_id}/transfer_progress'
-            try:
-                self.fw_progress_chunk = open(path, 'r')
-            except (PermissionError, FileNotFoundError) as err:
-                print(f'IMX500: Unable to open {path} ({err}). Firmware upload progress bar will not be displayed')
+                self.fw_progress = IMX500.FwProgressType.INDIRECT
+                self._fw_progress_read()
+                self._fw_progress_chunk_read()
+            except subprocess.CalledProcessError:
+                self.fw_progress = IMX500.FwProgressType.NONE
+                print("IMX500 firmware update progress bar is not available")
 
         if self.config['network_file'] != '':
             if tensor_injection:
@@ -361,6 +369,22 @@ class IMX500:
 
         full_sensor = self.__get_full_sensor_resolution()
         self.set_inference_roi_abs(full_sensor.to_tuple())
+
+    def _fw_progress_read(self):
+        assert self.fw_progress != IMX500.FwProgressType.NONE
+        if self.fw_progress == IMX500.FwProgressType.DIRECT:
+            cmd = ["cat", f"/sys/kernel/debug/imx500-fw:{self.imx500_device_id}/fw_progress"]
+        else:
+            cmd = ["sudo", "-n", "/usr/sbin/debug_stream_imx500.sh", f"{self.imx500_device_id}"]
+        return subprocess.check_output(cmd, stderr=subprocess.DEVNULL, text=True)
+
+    def _fw_progress_chunk_read(self):
+        assert self.fw_progress != IMX500.FwProgressType.NONE
+        if self.fw_progress == IMX500.FwProgressType.DIRECT:
+            cmd = ["cat", f"/sys/kernel/debug/rp2040-spi:{self.spi_device_id}/transfer_progress"]
+        else:
+            cmd = ["sudo", "-n", "/usr/sbin/debug_stream_rp2040.sh", f"{self.spi_device_id}"]
+        return subprocess.check_output(cmd, stderr=subprocess.DEVNULL, text=True)
 
     @staticmethod
     def __get_full_sensor_resolution():
@@ -449,16 +473,13 @@ class IMX500:
         size = 0
         stage = 0
 
-        if self.fw_progress:
-            self.fw_progress.seek(0)
-            progress = self.fw_progress.readline().strip().split()
-            stage = int(progress[0])
-            progress_block = int(progress[1])
-            size = int(progress[2])
+        # We have already checked that we can read this information successfully.
+        progress = self._fw_progress_read().strip().split()
+        stage = int(progress[0])
+        progress_block = int(progress[1])
+        size = int(progress[2])
 
-        if self.fw_progress_chunk:
-            self.fw_progress_chunk.seek(0)
-            progress_chunk = int(self.fw_progress_chunk.readline().strip())
+        progress_chunk = int(self._fw_progress_chunk_read().strip())
 
         if stage == stage_req:
             return (min(progress_block + progress_chunk, size), size)
@@ -466,8 +487,8 @@ class IMX500:
             return (0, 0)
 
     def show_network_fw_progress_bar(self):
-        if not self.fw_progress and not self.fw_progress_chunk:
-            # No readable progress source: skip the bar so the worker does not spin on (0, 0).
+        if self.fw_progress == IMX500.FwProgressType.NONE:
+            # No readable progress source: skip the bar entirely.
             return
         p = multiprocessing.Process(target=self.__do_progress_bar, args=(FW_NETWORK_STAGE, 'Network Firmware Upload'))
         p.start()

--- a/picamera2/devices/imx500/imx500_progress_bar.txt
+++ b/picamera2/devices/imx500/imx500_progress_bar.txt
@@ -1,0 +1,41 @@
+HOW TO MAKE THE IMX500 FIRMWARE UPLOAD PROGRESS BAR WORK FOR USERS WITHOUT SUDO PRIVELEGES
+
+These instructions explain how the firmware upload progress bar can be
+made to work for users without sudo priveleges, and who therefore
+can't open the necessary files in /sys/kernel/debug directly.
+
+It works by enabling a couple of small scripts that read these files
+for you, and then we enable them to run for *everyone* with
+password-less sudo.
+
+These instructions will need to be performed by someone with root
+access, but thereafter the progress bar should work for everyone.
+
+1. Fix the file permissions
+
+The two scripts in question are, in this folder:
+
+debug_stream_imx500.sh
+debug_stream_rp2040.sh
+
+First ensure they are owned by root and are non-writable.
+
+sudo chown root:root debug_stream_*
+sudo chmod 755 debug_stream_*
+
+NOTE: Doing this incorrectly exposes your system to security risks!
+
+2. Copy these scripts to /usr/sbin
+
+sudo cp debug_stream_* /usr/sbin
+
+3. Enable password-less sudo for these scripts
+
+Add the following two lines to the bottom of /etc/sudoers:
+
+%video	ALL=(root) NOPASSWD: /usr/sbin/debug_stream_imx500.sh
+%video	ALL=(root) NOPASSWD: /usr/sbin/debug_stream_rp2040.sh
+
+We suggest editing the file using "sudo visudo". This will allow
+members of the "video" group (which will include camera users) to run
+these scripts; or use a different group (or ALL) if you prefer.


### PR DESCRIPTION
We add a couple of little scripts to read the fw update status, and allow them to run for everyone with password-less sudo.

Please see imx500_progress_bar.txt for instructions on how to install and use this feature.